### PR TITLE
dr_msg_cb: Added support for message delivery callback

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -40,6 +40,7 @@ typedef struct _kafka_conf_callbacks {
     zval rk;
     kafka_conf_callback error;
     kafka_conf_callback rebalance;
+    kafka_conf_callback dr_msg;
 } kafka_conf_callbacks;
 
 typedef struct _kafka_conf_object {

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -658,4 +658,5 @@ void kafka_kafka_consumer_minit(TSRMLS_D) /* {{{ */
 
     zend_declare_property_null(ce, ZEND_STRL("error_cb"), ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_null(ce, ZEND_STRL("rebalance_cb"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(ce, ZEND_STRL("dr_msg_cb"), ZEND_ACC_PRIVATE TSRMLS_CC);
 } /* }}} */

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -648,6 +648,7 @@ PHP_MINIT_FUNCTION(rdkafka)
     ce_kafka->create_object = kafka_new;
 
     zend_declare_property_null(ce_kafka, ZEND_STRL("error_cb"), ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(ce_kafka, ZEND_STRL("dr_cb"), ZEND_ACC_PRIVATE TSRMLS_CC);
 
     INIT_NS_CLASS_ENTRY(ce, "RdKafka", "Consumer", kafka_consumer_fe);
     ce_kafka_consumer = zend_register_internal_class_ex(&ce, ce_kafka, NULL TSRMLS_CC);

--- a/tests/conf.phpt
+++ b/tests/conf.phpt
@@ -33,6 +33,11 @@ $conf->setErrorCb(function () { });
 $dump = $conf->dump();
 var_dump(isset($dump["error_cb"]));
 
+echo "Setting dr_msg callback\n";
+$conf->setDrMsgCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["dr_msg_cb"]));
+
 echo "Dumping conf\n";
 var_dump(array_intersect_key($conf->dump(), array(
     "client.id" => true,
@@ -49,6 +54,8 @@ Caught a RdKafka\Exception: Expected bool value for "topic.metadata.refresh.spar
 Setting an invalid property
 Caught a RdKafka\Exception: No such configuration property: "invalid"
 Setting error callback
+bool(true)
+Setting dr_msg callback
 bool(true)
 Dumping conf
 array(3) {


### PR DESCRIPTION
This adds support for the dr_msg_cb callback in rdkafka.

Prototype:
**public void RdKafka\Conf::setDrMsgCb ( callable $callback )**

Callback function:
**function dr_cb ($kafka, $msg) {**
_// Delivery Report_
**}**

thx to @ItzaPhenix aswell :)
