### PR TITLE
Stubs section has been added to the readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ $conf->set('internal.termination.signal', SIGIO);
 
 https://arnaud-lb.github.io/php-rdkafka/phpdoc/book.rdkafka.html
 
+## Stubs
+
+Because your IDE is not able to auto discover php-rdkadka api you can consider usage of external package providing a set of stubs for php-rdkafka classes, functions and constants: [kwn/php-rdkafka-stubs](https://github.com/kwn/php-rdkafka-stubs)
+
 ## Contributing
 
 If you would like to contribute, thank you :)


### PR DESCRIPTION
Hi @arnaud-lb 

Recently I've created a set of stubs for the IDE (https://github.com/kwn/php-rdkafka-stubs). Stubs are up to date with the current master branch of `php-rdkafka`, and they are provide more features than hauptmedia/php-rdkafka (e.g constants and functions). I'm going to maintain that repository as well, because it seems hauptmedia has abandoned his set of stubs. 
