### PR TITLE
Remove fprintf(stderr, "DESTRUCT\n"); from destructor

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -164,7 +164,6 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__KafkaConsumer, __destruct)
 {
-    fprintf(stderr, "DESTRUCT\n");
     object_intern *intern;
     rd_kafka_resp_err_t err;
 


### PR DESCRIPTION
Why should php-rdkafka write `DESTRUCT` to stderr on every `__destruct()` call?
