### PR TITLE
Windows support for PHP 7

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -1,2 +1,2 @@
 rdkafka
-Arnaud Le Blanc [lbarnaud] <arnaud.lb@gmail.com> (lead)
+Arnaud Le Blanc

--- a/config.w32
+++ b/config.w32
@@ -1,13 +1,22 @@
 // $Id$
 // vim:ft=javascript
 
-// If your extension references something external, use ARG_WITH
-// ARG_WITH("rdkafka", "for rdkafka support", "no");
-
-// Otherwise, use ARG_ENABLE
-// ARG_ENABLE("rdkafka", "enable rdkafka support", "no");
+ARG_WITH("rdkafka", "for rdkafka support", "no");
 
 if (PHP_RDKAFKA != "no") {
-	EXTENSION("rdkafka", "rdkafka.c");
+	if (CHECK_LIB("librdkafka.lib", "rdkafka", PHP_RDKAFKA) &&
+		CHECK_HEADER_ADD_INCLUDE("librdkafka/rdkafka.h", "CFLAGS_RDKAFKA")) {
+
+		AC_DEFINE('HAVE_RD_KAFKA_MSG_PARTIIONER_CONSISTENT', 1, '');
+		AC_DEFINE('HAVE_RD_KAFKA_GET_ERR_DESCS', 1, '');
+		AC_DEFINE('HAVE_NEW_KAFKA_CONSUMER', 1, '');
+		EXTENSION("rdkafka", "rdkafka.c metadata.c metadata_broker.c metadata_topic.c \
+				metadata_partition.c metadata_collection.c compat.c conf.c \
+				topic.c queue.c message.c fun.c kafka_consumer.c topic_partition.c");
+
+		AC_DEFINE('HAVE_RDKAFKA', 1, '');
+	} else {
+		WARNING("rdkafka not enabled; libraries and headers not found");
+	}
 }
 

--- a/metadata_collection.c
+++ b/metadata_collection.c
@@ -99,7 +99,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
     }
     
     for (i = 0; i < intern->item_cnt; i++) {
-        intern->ctor(&item, &intern->zmetadata, intern->items + i * intern->item_size TSRMLS_CC);
+        intern->ctor(&item, &intern->zmetadata, (char *)intern->items + i * intern->item_size TSRMLS_CC);
         add_next_index_zval(&ary, &item);
     }
 
@@ -177,7 +177,7 @@ PHP_METHOD(RdKafka__Metadata__Collection, current)
         return;
     }
 
-    intern->ctor(return_value, &intern->zmetadata, intern->items + intern->position * intern->item_size TSRMLS_CC);
+    intern->ctor(return_value, &intern->zmetadata, (char *)intern->items + intern->position * intern->item_size TSRMLS_CC);
 }
 /* }}} */
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -134,7 +134,9 @@ static kafka_object * get_kafka_object(zval *zrk TSRMLS_DC)
 
 static void kafka_log_syslog_print(const rd_kafka_t *rk, int level, const char *fac, const char *buf) {
     rd_kafka_log_print(rk, level, fac, buf);
+#ifndef PHP_WIN32
     rd_kafka_log_syslog(rk, level, fac, buf);
+#endif
 }
 
 /* {{{ private constructor */
@@ -456,8 +458,10 @@ PHP_METHOD(RdKafka__Kafka, setLogger)
             logger = rd_kafka_log_print;
             break;
         case RD_KAFKA_LOG_SYSLOG:
+#ifndef PHP_WIN32
             logger = rd_kafka_log_syslog;
             break;
+#endif
         case RD_KAFKA_LOG_SYSLOG_PRINT:
             logger = kafka_log_syslog_print;
             break;

--- a/tests/conf_setDefaultTopicConf.phpt
+++ b/tests/conf_setDefaultTopicConf.phpt
@@ -21,5 +21,5 @@ $conf->setDefaultTopicConf($conf);
 Setting valid topic conf
 Setting invalid topic conf
 
-Warning: RdKafka\Conf::setDefaultTopicConf() expects parameter 1 to be RdKafka\TopicConf, object given in %s/conf_setDefaultTopicConf.php on line 9
+Warning: RdKafka\Conf::setDefaultTopicConf() expects parameter 1 to be RdKafka\TopicConf, object given in %s%econf_setDefaultTopicConf.php on line 9
 


### PR DESCRIPTION
In general, just a proper config.w32 and some small fixes was required. The underlaying librkafka hevily relies on C99, thus VC14 only. While it possibly could be ported for VC11 support, it probably doesn't make much sense. Thus not doing 5.6 support.

The snapshots for this PR are available under

http://windows.php.net/downloads/pecl/snaps/rdkafka/2.0.0/

and the dependency libs here

http://windows.php.net/downloads/pecl/deps/

Thanks.
