### PR TITLE
kafka_object redefinition

### DIFF
--- a/rdkafka.c
+++ b/rdkafka.c
@@ -51,7 +51,7 @@ typedef struct _kafka_object {
     rd_kafka_t              *rk;
     kafka_conf_callbacks    cbs;
     HashTable               consuming;
-} kafka_object;
+};
 
 typedef struct _toppar {
     rd_kafka_topic_t    *rkt;


### PR DESCRIPTION
rdkafka.c:54: error: redefinition of typedef ‘kafka_object’
php_rdkafka_priv.h:30: note: previous declaration of ‘kafka_object’ was here
