### PR TITLE
Correct proto for RdKafka\Conf::set()

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -317,7 +317,7 @@ PHP_METHOD(RdKafka__Conf, dump)
 }
 /* }}} */
 
-/* {{{ proto void RdKafka\Conf::set(RdKafka\Conf $conf, string $name, string $value)
+/* {{{ proto void RdKafka\Conf::set(string $name, string $value)
    Sets a configuration property. */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_conf_set, 0, 0, 2)


### PR DESCRIPTION
The set() call proto had the old syntax, still including passing an instance of conf as the first argument. 