### PR TITLE
Adding a temp path in SEARCH_PATH for non-root compilation

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -6,7 +6,7 @@ PHP_ARG_WITH(rdkafka, for rdkafka support,
 
 if test "$PHP_RDKAFKA" != "no"; then
 
-  SEARCH_PATH="/usr/local /usr"     # you might want to change this
+  SEARCH_PATH="/usr/local /usr /tmp/librdkafka-staging/usr/local"     # you might want to change this
   SEARCH_FOR="/include/librdkafka/rdkafka.h"  # you most likely want to change this
   if test -r $PHP_RDKAFKA/$SEARCH_FOR; then # path given as parameter
     RDKAFKA_DIR=$PHP_RDKAFKA


### PR DESCRIPTION
Since it's not possible to use sudo command on container based image on Travis CI, we're installing librdkafka in /tmp. It's also not possible to tell pecl to use an alternative source of include and library path, this is why we need to have a tmp path in the SEARCH_PATH
