### PR TITLE
Fix building in Windows

### DIFF
--- a/metadata_collection.c
+++ b/metadata_collection.c
@@ -110,7 +110,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
     
     for (i = 0; i < intern->item_cnt; i++) {
         MAKE_STD_ZEVAL(item);
-        intern->ctor(P_ZEVAL(item), &intern->zmetadata, intern->items + i * intern->item_size TSRMLS_CC);
+        intern->ctor(P_ZEVAL(item), &intern->zmetadata, (char *)intern->items + i * intern->item_size TSRMLS_CC);
         add_next_index_zval(&ary, P_ZEVAL(item));
     }
 
@@ -188,7 +188,7 @@ PHP_METHOD(RdKafka__Metadata__Collection, current)
         return;
     }
 
-    intern->ctor(return_value, &intern->zmetadata, intern->items + intern->position * intern->item_size TSRMLS_CC);
+    intern->ctor(return_value, &intern->zmetadata, (char *)intern->items + intern->position * intern->item_size TSRMLS_CC);
 }
 /* }}} */
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -180,7 +180,9 @@ kafka_object * get_kafka_object(zval *zrk TSRMLS_DC)
 
 static void kafka_log_syslog_print(const rd_kafka_t *rk, int level, const char *fac, const char *buf) {
     rd_kafka_log_print(rk, level, fac, buf);
+#ifndef _MSC_VER
     rd_kafka_log_syslog(rk, level, fac, buf);
+#endif
 }
 
 void add_consuming_toppar(kafka_object * intern, rd_kafka_topic_t * rkt, int32_t partition) {
@@ -559,9 +561,11 @@ PHP_METHOD(RdKafka__Kafka, setLogger)
         case RD_KAFKA_LOG_PRINT:
             logger = rd_kafka_log_print;
             break;
+#ifndef _MSC_VER
         case RD_KAFKA_LOG_SYSLOG:
             logger = rd_kafka_log_syslog;
             break;
+#endif
         case RD_KAFKA_LOG_SYSLOG_PRINT:
             logger = kafka_log_syslog_print;
             break;


### PR DESCRIPTION
1. cast ``intern->items`` to ``char*``. Adding to a void* is a GCC extension, so in MSVC, we have to cast the pointer to a char*. See: http://gcc.gnu.org/onlinedocs/gcc/Pointer-Arith.html

1. Disable ``rd_kafka_log_syslog`` in MSVC as ``librdkafka`` did: https://github.com/edenhill/librdkafka/blob/1f7417d4796e036b8c19f17373f8290ff5c7561f/src/rdkafka.c#L261


This PR just fixed building on Windows.