### PR TITLE
message : expose len of rdkafka-message

### DIFF
--- a/message.c
+++ b/message.c
@@ -43,6 +43,7 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSR
     zend_update_property_long(NULL, return_value, ZEND_STRL("partition"), message->partition TSRMLS_CC);
     if (message->payload) {
         zend_update_property_stringl(NULL, return_value, ZEND_STRL("payload"), message->payload, message->len TSRMLS_CC);
+        zend_update_property_long(NULL, return_value, ZEND_STRL("len"), message->len TSRMLS_CC);
     }
     if (message->key) {
         zend_update_property_stringl(NULL, return_value, ZEND_STRL("key"), message->key, message->key_len TSRMLS_CC);
@@ -102,6 +103,7 @@ void kafka_message_minit(TSRMLS_D) { /* {{{ */
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("topic_name"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("partition"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("payload"), ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("len"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("key"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("offset"), ZEND_ACC_PUBLIC TSRMLS_CC);
 } /* }}} */


### PR DESCRIPTION
Hello,

We currently use your API with some php5 worker to consume very high throughput of Kafka message.
We need to get the length payload for each message but we encounter some perf issues to apply strlen on each string payload (and we cannot pass to php7 unfortunatly..).

php-rdkafka doesn't expose len value of the rdkafka-message and force to
apply strlen on the generate string into the php code to retrieve it.
Save this value into the memory will optimize the php client.

I'm not very familiar with Zend api but i think it can fix it.

Regards,