### PR TITLE
Add missing close method

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -530,7 +530,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, close)
     }
 
     rd_kafka_consumer_close(intern->rk);
-    intern->rk = null;
+    intern->rk = NULL;
 }
 /* }}} */
 

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -522,6 +522,8 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__KafkaConsumer, close)
 {
+    object_intern *intern;
+
     intern = get_object(getThis() TSRMLS_CC);
     if (!intern) {
         return;

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -514,6 +514,23 @@ PHP_METHOD(RdKafka__KafkaConsumer, commitAsync)
 }
 /* }}} */
 
+/* {{{ proto void RdKafka\KafkaConsumer::close()
+   Close connection */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_kafka_consumer_close, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(RdKafka__KafkaConsumer, close)
+{
+    intern = get_object(getThis() TSRMLS_CC);
+    if (!intern) {
+        return;
+    }
+
+    rd_kafka_consumer_close(intern->rk);
+}
+/* }}} */
+
 /* {{{ proto Metadata RdKafka\KafkaConsumer::getMetadata(bool all_topics, RdKafka\Topic only_topic, int timeout_ms)
    Request Metadata from broker */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_kafka_consumer_getMetadata, 0, 0, 3)
@@ -624,6 +641,7 @@ static const zend_function_entry fe[] = { /* {{{ */
     PHP_ME(RdKafka__KafkaConsumer, assign, arginfo_kafka_kafka_consumer_assign, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__KafkaConsumer, getAssignment, arginfo_kafka_kafka_consumer_getAssignment, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__KafkaConsumer, commit, arginfo_kafka_kafka_consumer_commit, ZEND_ACC_PUBLIC)
+    PHP_ME(RdKafka__KafkaConsumer, close, arginfo_kafka_kafka_consumer_close, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__KafkaConsumer, commitAsync, arginfo_kafka_kafka_consumer_commit_async, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__KafkaConsumer, consume, arginfo_kafka_kafka_consumer_consume, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__KafkaConsumer, subscribe, arginfo_kafka_kafka_consumer_subscribe, ZEND_ACC_PUBLIC)

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -530,6 +530,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, close)
     }
 
     rd_kafka_consumer_close(intern->rk);
+    intern->rk = null;
 }
 /* }}} */
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -582,7 +582,7 @@ PHP_METHOD(RdKafka__Kafka, setLogger)
             return;
     }
 
-    rd_kafka_set_logger(intern->rk, logger);
+    rd_kafka_conf_set_log_cb(intern->rk, logger);
 }
 /* }}} */
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -582,7 +582,7 @@ PHP_METHOD(RdKafka__Kafka, setLogger)
             return;
     }
 
-    rd_kafka_conf_set_log_cb(intern->rk, logger);
+    rd_kafka_set_logger(intern->rk, logger);
 }
 /* }}} */
 


### PR DESCRIPTION
Adds the possibility to explicitly close the connection between the consumer and the broker.

So far it only happens on complete dereference of consumer object which is not always possible.

See #75 