### PR TITLE
Fix #151 - Callbacks for `offset_commit` and `consume`

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -773,7 +773,7 @@ static const zend_function_entry kafka_conf_fe[] = {
     PHP_ME(RdKafka__Conf, setRebalanceCb, arginfo_kafka_conf_set_rebalance_cb, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__Conf, setConsumeCb, arginfo_kafka_conf_set_consume_cb, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__Conf, setOffsetCommitCb, arginfo_kafka_conf_set_offset_commit_cb, ZEND_ACC_PUBLIC)
-    #endif /* HAVE_NEW_KAFKA_CONSUMER */
+#endif /* HAVE_NEW_KAFKA_CONSUMER */
     PHP_FE_END
 };
 

--- a/conf.c
+++ b/conf.c
@@ -52,6 +52,8 @@ void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs TSRMLS_DC) /* {{{ */
     kafka_conf_callback_dtor(cbs->rebalance TSRMLS_CC);
     kafka_conf_callback_dtor(cbs->dr_msg TSRMLS_CC);
     kafka_conf_callback_dtor(cbs->stats TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->consume TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->offset_commit TSRMLS_CC);
 } /* }}} */
 
 static void kafka_conf_callback_copy(kafka_conf_callback **to, kafka_conf_callback *from TSRMLS_DC) /* {{{ */
@@ -73,6 +75,8 @@ void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *f
     kafka_conf_callback_copy(&to->rebalance, from->rebalance TSRMLS_CC);
     kafka_conf_callback_copy(&to->dr_msg, from->dr_msg TSRMLS_CC);
     kafka_conf_callback_copy(&to->stats, from->stats TSRMLS_CC);
+    kafka_conf_callback_copy(&to->consume, from->consume TSRMLS_CC);
+    kafka_conf_callback_copy(&to->offset_commit, from->offset_commit TSRMLS_CC);
 } /* }}} */
 
 static void kafka_conf_free(zend_object *object TSRMLS_DC) /* {{{ */
@@ -237,6 +241,65 @@ static void kafka_conf_rebalance_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, rd_
     kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions TSRMLS_CC);
 
     rdkafka_call_function(&cbs->rebalance->fci, &cbs->rebalance->fcc, NULL, 3, args TSRMLS_CC);
+
+    zval_ptr_dtor(&args[0]);
+    zval_ptr_dtor(&args[1]);
+    zval_ptr_dtor(&args[2]);
+}
+#endif /* HAVE_NEW_KAFKA_CONSUMER */
+
+#ifdef HAVE_NEW_KAFKA_CONSUMER
+static void kafka_conf_consume_cb(rd_kafka_message_t *msg, void *opaque)
+{
+    kafka_conf_callbacks *cbs = (kafka_conf_callbacks*) opaque;
+    zeval args[2];
+    TSRMLS_FETCH();
+
+    if (!opaque) {
+        return;
+    }
+
+    if (!cbs->consume) {
+        return;
+    }
+
+    MAKE_STD_ZEVAL(args[0]);
+    MAKE_STD_ZEVAL(args[1]);
+
+            KAFKA_ZVAL_ZVAL(P_ZEVAL(args[0]), &cbs->rk, 1, 0);
+    kafka_message_new(P_ZEVAL(args[1]), msg TSRMLS_CC);
+
+    rdkafka_call_function(&cbs->consume->fci, &cbs->consume->fcc, NULL, 2, args TSRMLS_CC);
+
+    zval_ptr_dtor(&args[0]);
+    zval_ptr_dtor(&args[1]);
+}
+#endif /* HAVE_NEW_KAFKA_CONSUMER */
+
+#ifdef HAVE_NEW_KAFKA_CONSUMER
+static void kafka_conf_offset_commit_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, rd_kafka_topic_partition_list_t *partitions, void *opaque)
+{
+    kafka_conf_callbacks *cbs = (kafka_conf_callbacks*) opaque;
+    zeval args[3];
+    TSRMLS_FETCH();
+
+    if (!opaque) {
+        return;
+    }
+
+    if (!cbs->offset_commit) {
+        return;
+    }
+
+    MAKE_STD_ZEVAL(args[0]);
+    MAKE_STD_ZEVAL(args[1]);
+    MAKE_STD_ZEVAL(args[2]);
+
+    KAFKA_ZVAL_ZVAL(P_ZEVAL(args[0]), &cbs->rk, 1, 0);
+    ZVAL_LONG(P_ZEVAL(args[1]), err);
+    kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions TSRMLS_CC);
+
+    rdkafka_call_function(&cbs->offset_commit->fci, &cbs->offset_commit->fcc, NULL, 3, args TSRMLS_CC);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -550,6 +613,84 @@ PHP_METHOD(RdKafka__Conf, setRebalanceCb)
 /* }}} */
 #endif /* HAVE_NEW_KAFKA_CONSUMER */
 
+#ifdef HAVE_NEW_KAFKA_CONSUMER
+/* {{{ proto void RdKafka\Conf::setConsumeCb(callable $callback)
+   Set consume callback to use with poll */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_conf_set_consume_cb, 0, 0, 1)
+                ZEND_ARG_INFO(0, callback)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(RdKafka__Conf, setConsumeCb)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    kafka_conf_object *intern;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    if (!intern) {
+        return;
+    }
+
+    Z_ADDREF_P(P_ZEVAL(fci.function_name));
+
+    if (intern->cbs.consume) {
+        zval_ptr_dtor(&intern->cbs.consume->fci.function_name);
+    } else {
+        intern->cbs.consume = ecalloc(1, sizeof(*intern->cbs.consume));
+    }
+
+    intern->cbs.consume->fci = fci;
+    intern->cbs.consume->fcc = fcc;
+
+    rd_kafka_conf_set_consume_cb(intern->u.conf, kafka_conf_consume_cb);
+}
+/* }}} */
+#endif /* HAVE_NEW_KAFKA_CONSUMER */
+
+#ifdef HAVE_NEW_KAFKA_CONSUMER
+/* {{{ proto void RdKafka\Conf::setOffsetCommitCb(mixed $callback)
+   Set offset commit callback for use with consumer groups */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_conf_set_offset_commit_cb, 0, 0, 1)
+    ZEND_ARG_INFO(0, callback)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(RdKafka__Conf, setOffsetCommitCb)
+{
+    zend_fcall_info fci;
+    zend_fcall_info_cache fcc;
+    kafka_conf_object *intern;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    if (!intern) {
+        return;
+    }
+
+    Z_ADDREF_P(P_ZEVAL(fci.function_name));
+
+    if (intern->cbs.offset_commit) {
+        zval_ptr_dtor(&intern->cbs.offset_commit->fci.function_name);
+    } else {
+        intern->cbs.offset_commit = ecalloc(1, sizeof(*intern->cbs.offset_commit));
+    }
+
+    intern->cbs.offset_commit->fci = fci;
+    intern->cbs.offset_commit->fcc = fcc;
+
+    rd_kafka_conf_set_offset_commit_cb(intern->u.conf, kafka_conf_offset_commit_cb);
+}
+/* }}} */
+#endif /* HAVE_NEW_KAFKA_CONSUMER */
+
 /* {{{ proto RdKafka\TopicConf::__construct() */
 PHP_METHOD(RdKafka__TopicConf, __construct)
 {
@@ -630,7 +771,9 @@ static const zend_function_entry kafka_conf_fe[] = {
     PHP_ME(RdKafka__Conf, setStatsCb, arginfo_kafka_conf_set_stats_cb, ZEND_ACC_PUBLIC)
 #ifdef HAVE_NEW_KAFKA_CONSUMER
     PHP_ME(RdKafka__Conf, setRebalanceCb, arginfo_kafka_conf_set_rebalance_cb, ZEND_ACC_PUBLIC)
-#endif /* HAVE_NEW_KAFKA_CONSUMER */
+    PHP_ME(RdKafka__Conf, setConsumeCb, arginfo_kafka_conf_set_consume_cb, ZEND_ACC_PUBLIC)
+    PHP_ME(RdKafka__Conf, setOffsetCommitCb, arginfo_kafka_conf_set_offset_commit_cb, ZEND_ACC_PUBLIC)
+    #endif /* HAVE_NEW_KAFKA_CONSUMER */
     PHP_FE_END
 };
 

--- a/conf.h
+++ b/conf.h
@@ -42,6 +42,8 @@ typedef struct _kafka_conf_callbacks {
     kafka_conf_callback *rebalance;
     kafka_conf_callback *dr_msg;
     kafka_conf_callback *stats;
+    kafka_conf_callback *consume;
+    kafka_conf_callback *offset_commit;
 } kafka_conf_callbacks;
 
 typedef struct _kafka_conf_object {

--- a/tests/conf.phpt
+++ b/tests/conf.phpt
@@ -43,6 +43,16 @@ $conf->setStatsCb(function () { });
 $dump = $conf->dump();
 var_dump(isset($dump["stats_cb"]));
 
+echo "Setting consume callback\n";
+$conf->setConsumeCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["consume_cb"]));
+
+echo "Setting offset_commit callback\n";
+$conf->setOffsetCommitCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["offset_commit_cb"]));
+
 echo "Dumping conf\n";
 var_dump(array_intersect_key($conf->dump(), array(
     "client.id" => true,
@@ -63,6 +73,10 @@ bool(true)
 Setting dr_msg callback
 bool(true)
 Setting stats callback
+bool(true)
+Setting consume callback
+bool(true)
+Setting offset_commit callback
 bool(true)
 Dumping conf
 array(3) {

--- a/tests/conf.phpt
+++ b/tests/conf.phpt
@@ -43,16 +43,6 @@ $conf->setStatsCb(function () { });
 $dump = $conf->dump();
 var_dump(isset($dump["stats_cb"]));
 
-echo "Setting consume callback\n";
-$conf->setConsumeCb(function () { });
-$dump = $conf->dump();
-var_dump(isset($dump["consume_cb"]));
-
-echo "Setting offset_commit callback\n";
-$conf->setOffsetCommitCb(function () { });
-$dump = $conf->dump();
-var_dump(isset($dump["offset_commit_cb"]));
-
 echo "Dumping conf\n";
 var_dump(array_intersect_key($conf->dump(), array(
     "client.id" => true,
@@ -73,10 +63,6 @@ bool(true)
 Setting dr_msg callback
 bool(true)
 Setting stats callback
-bool(true)
-Setting consume callback
-bool(true)
-Setting offset_commit callback
 bool(true)
 Dumping conf
 array(3) {

--- a/tests/conf_callbacks.phpt
+++ b/tests/conf_callbacks.phpt
@@ -1,0 +1,33 @@
+--TEST--
+RdKafka\Conf
+--SKIPIF--
+<?php
+RD_KAFKA_VERSION >= 0x090000 || die("skip");
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+
+echo "Setting consume callback\n";
+$conf->setConsumeCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["consume_cb"]));
+
+echo "Setting offset_commit callback\n";
+$conf->setOffsetCommitCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["offset_commit_cb"]));
+
+echo "Setting rebalance callback\n";
+$conf->setRebalanceCb(function () { });
+$dump = $conf->dump();
+var_dump(isset($dump["rebalance_cb"]));
+
+
+--EXPECT--
+Setting consume callback
+bool(true)
+Setting offset_commit callback
+bool(true)
+Setting rebalance callback
+bool(true)

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -1,0 +1,71 @@
+--TEST--
+RdKafka\Conf
+--SKIPIF--
+<?php
+RD_KAFKA_VERSION >= 0x090000 || die("skip");
+file_exists(__DIR__."/test_env.php") || die("skip");
+--FILE--
+<?php
+
+require __DIR__."/test_env.php";
+
+$conf = new RdKafka\Conf();
+
+$topicConf = new RdKafka\TopicConf();
+$topicConf->set('auto.offset.reset', 'smallest');
+
+$conf->setDefaultTopicConf($topicConf);
+$conf->set('metadata.broker.list', TEST_KAFKA_BROKERS);
+$conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
+
+$conf->setOffsetCommitCb(function ($consumer, $error, $topicPartitions) {
+    echo "Offset " . $topicPartitions[0]->getOffset() . " committed.\n";
+});
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+$topic = $producer->newTopic($topicName);
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i");
+    $producer->poll(0);
+}
+
+while ($producer->getOutQLen()) {
+    $producer->poll(50);
+}
+
+$consumer = new RdKafka\KafkaConsumer($conf);
+$consumer->subscribe([$topicName]);
+
+while (true) {
+    $msg = $consumer->consume(60 * 1000);
+
+    if (!$msg) {
+        continue;
+    }
+
+    switch ($msg->err) {
+        case RD_KAFKA_RESP_ERR_NO_ERROR:
+            $consumer->commit($msg);
+
+            break;
+        case RD_KAFKA_RESP_ERR__PARTITION_EOF:
+            break 2;
+        default:
+            throw new Exception($msg->errstr());
+    }
+}
+
+--EXPECT--
+Offset 1 committed.
+Offset 2 committed.
+Offset 3 committed.
+Offset 4 committed.
+Offset 5 committed.
+Offset 6 committed.
+Offset 7 committed.
+Offset 8 committed.
+Offset 9 committed.
+Offset 10 committed.


### PR DESCRIPTION
This PR adds support for the `offset_commit` and `consume` callbacks.

They have been added under the preprocessor `HAVE_NEW_KAFKA_CONSUMER`.