### PR TITLE
Drop unmaintained PHP versions from travis build and add 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: true
 language: php
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
 env:
     - LIBRDKAFKA_VERSION=0.8.6
     - LIBRDKAFKA_VERSION=0.8


### PR DESCRIPTION
PHP versions `5.4` and `5.5` have officially reached EOL, we can safely drop them from the travis build.

Additionally we should start building against `7.2`