### PR TITLE
Fix arginfo for RdKafka\TopicConf::set

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -754,7 +754,7 @@ PHP_METHOD(RdKafka__TopicConf, setPartitioner)
 static const zend_function_entry kafka_topic_conf_fe[] = {
     PHP_ME(RdKafka__TopicConf, __construct, arginfo_kafka_conf___construct, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__Conf, dump, arginfo_kafka_conf_dump, ZEND_ACC_PUBLIC)
-    PHP_ME(RdKafka__Conf, set, arginfo_kafka_conf_dump, ZEND_ACC_PUBLIC)
+    PHP_ME(RdKafka__Conf, set, arginfo_kafka_conf_set, ZEND_ACC_PUBLIC)
     PHP_ME(RdKafka__TopicConf, setPartitioner, arginfo_kafka_topic_conf_set_partitioner, ZEND_ACC_PUBLIC)
     PHP_FE_END
 };


### PR DESCRIPTION
While using PHPStan, I've found a miss arginfo:

```sh
 ------ ------------------------------------------------------------------------ 
  Line   src/Connectors/Consumer/LowLevel.php                                    
 ------ ------------------------------------------------------------------------ 
  51     Method RdKafka\TopicConf::set() invoked with 2 parameters, 0 required.  
 ------ ------------------------------------------------------------------------ 
```