### PR TITLE
Message headers support

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -63,6 +63,12 @@ if test "$PHP_RDKAFKA" != "no"; then
     AC_MSG_WARN([no rd_kafka_message_timestamp, timestamp support will not be available])
   ])
 
+  AC_CHECK_LIB($LIBNAME,[rd_kafka_message_headers],[
+    AC_DEFINE(HAVE_RD_KAFKA_MESSAGE_HEADERS,1,[ ])
+  ],[
+    AC_MSG_WARN([no rd_kafka_message_headers, headers support will not be available])
+  ])
+
   AC_CHECK_LIB($LIBNAME,[rd_kafka_subscribe],[
     AC_DEFINE(HAVE_NEW_KAFKA_CONSUMER,1,[ ])
     SOURCES="$SOURCES kafka_consumer.c topic_partition.c"

--- a/message.c
+++ b/message.c
@@ -43,6 +43,16 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSR
     timestamp = rd_kafka_message_timestamp(message, &tstype);
 #endif /* HAVE_RD_KAFKA_MESSAGE_TIMESTAMP */
 
+#ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
+    rd_kafka_headers_t *message_headers = NULL;
+    rd_kafka_resp_err_t header_response;
+    const char *header_name = NULL;
+    const void *header_value = NULL;
+    size_t header_size = 0;
+    zval headers_array;
+    int i;
+#endif /* HAVE_RD_KAFKA_MESSAGE_HEADERS */
+
     zend_update_property_long(NULL, return_value, ZEND_STRL("err"), message->err TSRMLS_CC);
 
     if (message->rkt) {
@@ -60,6 +70,21 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSR
         zend_update_property_stringl(NULL, return_value, ZEND_STRL("key"), message->key, message->key_len TSRMLS_CC);
     }
     zend_update_property_long(NULL, return_value, ZEND_STRL("offset"), message->offset TSRMLS_CC);
+
+#ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
+    rd_kafka_message_headers(message, &message_headers);
+    if (message_headers != NULL) {
+        array_init(&headers_array);
+        for (i = 0; i < rd_kafka_header_cnt(message_headers); i++) {
+            header_response = rd_kafka_header_get_all(message_headers, i, &header_name, &header_value, &header_size);
+            if (header_response != RD_KAFKA_RESP_ERR_NO_ERROR) {
+                break;
+            }
+            rdkafka_add_assoc_string(&headers_array, header_name, (char*)header_value);
+        }
+        zend_update_property(NULL, return_value, ZEND_STRL("headers"), &headers_array TSRMLS_CC);
+    }
+#endif
 }
 
 /* {{{ proto string RdKafka\Message::errstr()
@@ -120,4 +145,7 @@ void kafka_message_minit(TSRMLS_D) { /* {{{ */
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("len"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("key"), ZEND_ACC_PUBLIC TSRMLS_CC);
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("offset"), ZEND_ACC_PUBLIC TSRMLS_CC);
+#ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("headers"), ZEND_ACC_PUBLIC TSRMLS_CC);
+#endif
 } /* }}} */

--- a/php_rdkafka_priv.h
+++ b/php_rdkafka_priv.h
@@ -99,6 +99,18 @@ static inline zval *rdkafka_hash_get_current_data_ex(HashTable *ht, HashPosition
     return zend_hash_get_current_data_ex(ht, pos);
 }
 
+static inline char *rdkafka_hash_get_current_key_ex(HashTable *ht, HashPosition *pos)
+{
+    zend_string* key;
+    zend_ulong index;
+
+    if (zend_hash_get_current_key_ex(ht, &key, &index, pos) == HASH_KEY_IS_STRING) {
+        return key->val;
+    }
+
+    return NULL;
+}
+
 #define rdkafka_add_assoc_string(arg, key, str) add_assoc_string(arg, key, str)
 
 #define RDKAFKA_RETURN_STRING(str) RETURN_STRING(str)
@@ -209,6 +221,19 @@ static inline zval **rdkafka_hash_get_current_data_ex(HashTable *ht, HashPositio
 
     if (zend_hash_get_current_data_ex(ht, (void**)&zv, pos) == SUCCESS) {
         return zv;
+    }
+
+    return NULL;
+}
+
+static inline char **rdkafka_hash_get_current_key_ex(HashTable *ht, HashPosition *pos)
+{
+    char *key = NULL;
+    uint  klen;
+    ulong index;
+
+    if (zend_hash_get_current_key_ex(ht, &key, &klen, &index, 0, pos) == HASH_KEY_IS_STRING) {
+        return key;
     }
 
     return NULL;

--- a/tests/message_headers.phpt
+++ b/tests/message_headers.phpt
@@ -1,0 +1,104 @@
+--TEST--
+Message headers
+--SKIPIF--
+<?php
+RD_KAFKA_VERSION >= 0x000b04ff || die("skip");
+file_exists(__DIR__."/test_env.php") || die("skip");
+--FILE--
+<?php
+
+require __DIR__."/test_env.php";
+
+$delivered = 0;
+
+$conf = new RdKafka\Conf();
+$conf->setErrorCb(function ($producer, $err, $errstr) {
+    printf("%s: %s\n", rd_kafka_err2str($err), $errstr);
+    exit;
+});
+$conf->setDrMsgCb(function ($producer, $msg) use (&$delivered) {
+    if ($msg->err) {
+        throw new Exception("Message delivery failed: " . $msg->errstr());
+    }
+    $delivered++;
+});
+
+$producer = new RdKafka\Producer($conf);
+
+if ($producer->addBrokers(TEST_KAFKA_BROKERS) < 1) {
+    echo "Failed adding brokers\n";
+    exit;
+}
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+$headers = [
+    ['key' => 'value'],
+    [
+        'key1' => 'value1',
+        'key2' => 'value2',
+        'key3' => 'value3',
+    ],
+    [],
+    null,
+    ['key'],
+];
+
+foreach ($headers as $index => $header) {
+    $topic->producev(0, 0, "message $index", null, $header);
+    $producer->poll(0);
+}
+
+while ($producer->getOutQLen()) {
+    $producer->poll(50);
+}
+
+printf("%d messages delivered\n", $delivered);
+
+$consumer = new RdKafka\Consumer($conf);
+$consumer->addBrokers(TEST_KAFKA_BROKERS);
+
+$topic = $consumer->newTopic($topicName);
+$topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);
+
+$messages = [];
+
+while (true) {
+    $msg = $topic->consume(0, 60*1000);
+    if (!$msg) {
+        continue;
+    }
+    switch ($msg->err) {
+        case RD_KAFKA_RESP_ERR_NO_ERROR:
+            $headersString = $msg->headers ?? [];
+            array_walk($headersString, function(&$value, $key) {
+                $value = "{$key}: {$value}";
+            });
+            if (empty($headersString)) {
+                $headersString = "none";
+            } else {
+                $headersString = implode(", ", $headersString);
+            }
+            printf("Got message: %s | Headers: %s\n", $msg->payload, $headersString);
+            break;
+        case RD_KAFKA_RESP_ERR__PARTITION_EOF:
+            echo "EOF\n";
+            break 2;
+        default:
+            throw new Exception($message->errstr());
+    }
+}
+--EXPECT--
+5 messages delivered
+Got message: message 0 | Headers: key: value
+Got message: message 1 | Headers: key1: value1, key2: value2, key3: value3
+Got message: message 2 | Headers: none
+Got message: message 3 | Headers: none
+Got message: message 4 | Headers: none
+EOF

--- a/topic.c
+++ b/topic.c
@@ -401,6 +401,7 @@ PHP_METHOD(RdKafka__ProducerTopic, produce)
 }
 /* }}} */
 
+#ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
 /* {{{ proto void RdKafka\ProducerTopic::producev(int $partition, int $msgflags[, string $payload, string $key, array $headers])
    Produce and send a single message to broker (with headers possibility). */
 
@@ -480,11 +481,14 @@ PHP_METHOD(RdKafka__ProducerTopic, producev)
     }
 }
 /* }}} */
+#endif
 
 static const zend_function_entry kafka_producer_topic_fe[] = {
     PHP_ME(RdKafka, __construct, arginfo_kafka___private_construct, ZEND_ACC_PRIVATE)
     PHP_ME(RdKafka__ProducerTopic, produce, arginfo_kafka_produce, ZEND_ACC_PUBLIC)
+#ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
     PHP_ME(RdKafka__ProducerTopic, producev, arginfo_kafka_producev, ZEND_ACC_PUBLIC)
+#endif
     PHP_FE_END
 };
 


### PR DESCRIPTION
### Message headers support

**Requirements:**
- [librdkafka](https://github.com/edenhill/librdkafka) >= 0.11.4
- Kafka >= 0.11.0.0


**Usage:**
_Produce:_ you need to use `producev` function instead of `produce`.

> producev(int $partition, int $msgflags[, string $payload, string $key, array $headers])

_Consume:_ just use `$message->headers` to retrieve all message headers.


**Structure:**
`producev` accepts only associative array (or null):

> ['key1' => 'value1', 'key2' => 'value2']

`$message->headers` returns associative array or null if no headers.




Requested in #197 