### PR TITLE
expose flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ https://arnaud-lb.github.io/php-rdkafka/phpdoc/rdkafka.examples.html
 
 ### Producing
 
+#### Creating a producer
 For producing, we first need to create a producer, and to add brokers (Kafka
 servers) to it:
 
@@ -53,6 +54,7 @@ $rk = new RdKafka\Producer($conf);
 $rk->addBrokers("10.0.0.1:9092,10.0.0.2:9092");
 ```
 
+#### Producing messages
 Next, we create a topic instance from the producer:
 
 ``` php
@@ -76,6 +78,20 @@ The first argument is the partition. RD_KAFKA_PARTITION_UA stands for
 The second argument are message flags and should always be 0, currently.
 
 The message payload can be anything.
+
+#### Proper shutdown
+This should typically be done prior to destroying a producer instance  
+to make sure all queued and in-flight produce requests are completed  
+before terminating. Use a reasonable value for $timeout_ms.
+```php
+$rk->flush($timeout_ms);
+```
+Optionally, you can purge all messages from the queue that haven't  
+been sent to the broker yet, before calling flush.
+```php
+$rk->purge(RD_KAFKA_PURGE_F_QUEUE);
+$rk->flush($timeout_ms);
+```
 
 ### High-level consuming
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -86,9 +86,6 @@ static void kafka_free(zend_object *object TSRMLS_DC) /* {{{ */
         }
         zend_hash_destroy(&intern->topics);
 
-        while (rd_kafka_outq_len(intern->rk) > 0) {
-            rd_kafka_poll(intern->rk, 1);
-        }
         rd_kafka_destroy(intern->rk);
         intern->rk = NULL;
     }

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -545,10 +545,34 @@ PHP_METHOD(RdKafka__Kafka, poll)
 
     RETURN_LONG(rd_kafka_poll(intern->rk, timeout));
 }
-
-#ifdef HAS_RD_KAFKA_PURGE
 /* }}} */
 
+/* {{{ proto int RdKafka\Kafka::flush(int $timeout_ms)
+   Wait until all outstanding produce requests, et.al, are completed. */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka_flush, 0, 0, 1)
+    ZEND_ARG_INFO(0, timeout_ms)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(RdKafka__Kafka, flush)
+{
+    kafka_object *intern;
+    long timeout;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout) == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_object(getThis() TSRMLS_CC);
+    if (!intern) {
+        return;
+    }
+
+    RETURN_LONG(rd_kafka_flush(intern->rk, timeout));
+}
+/* }}} */
+
+#ifdef HAS_RD_KAFKA_PURGE
 /* {{{ proto int RdKafka\Kafka::purge(int $purge_flags)
    Purge messages that are in queue or in flight */
 
@@ -713,6 +737,7 @@ static const zend_function_entry kafka_fe[] = {
     PHP_ME(RdKafka__Kafka, newTopic, arginfo_kafka_new_topic, ZEND_ACC_PUBLIC)
     PHP_MALIAS(RdKafka__Kafka, outqLen, getOutQLen, arginfo_kafka_get_outq_len, ZEND_ACC_PUBLIC | ZEND_ACC_DEPRECATED)
     PHP_ME(RdKafka__Kafka, poll, arginfo_kafka_poll, ZEND_ACC_PUBLIC)
+    PHP_ME(RdKafka__Kafka, flush, arginfo_kafka_flush, ZEND_ACC_PUBLIC)
 #ifdef HAS_RD_KAFKA_PURGE
     PHP_ME(RdKafka__Kafka, purge, arginfo_kafka_purge, ZEND_ACC_PUBLIC)
 #endif


### PR DESCRIPTION
@arnaud-lb i removed the poll in the destructor, because of issue https://github.com/arnaud-lb/php-rdkafka/issues/196, where the problem is, that when the broker is not available, the poll hangs forever in the destructor (because unlike for flush, there is no timeout). With flush and purge exposed, this gives the user enough flexibility to handle this on it's own i think.
Let me know what you think

Relates to: https://github.com/arnaud-lb/php-rdkafka/pull/144