### PR TITLE
remove obsolete wait destroyed

### DIFF
--- a/rdkafka.c
+++ b/rdkafka.c
@@ -818,7 +818,6 @@ PHP_MINIT_FUNCTION(rdkafka)
  */
 PHP_MSHUTDOWN_FUNCTION(rdkafka)
 {
-    rd_kafka_wait_destroyed(1000);
     return SUCCESS;
 }
 /* }}} */


### PR DESCRIPTION
@arnaud-lb i greated a 3.1.x branch from the latest commit of 3.1.2, so we can use it for bugfixes.
This PR is regarding #76 #162 (windows support) and to get rid of an obsolete call that causes SEGFALT