### PR TITLE
Fix test case for Windows

### DIFF
--- a/tests/conf_setDefaultTopicConf.phpt
+++ b/tests/conf_setDefaultTopicConf.phpt
@@ -20,10 +20,10 @@ $conf->setDefaultTopicConf($conf);
 --EXPECTF--
 Setting valid topic conf
 
-Deprecated: Function RdKafka\Conf::setDefaultTopicConf() is deprecated in %s/conf_setDefaultTopicConf.php on line 6
+Deprecated: Function RdKafka\Conf::setDefaultTopicConf() is deprecated in %s%econf_setDefaultTopicConf.php on line 6
 Setting invalid topic conf
 
-Deprecated: Function RdKafka\Conf::setDefaultTopicConf() is deprecated in %s/conf_setDefaultTopicConf.php on line 9
+Deprecated: Function RdKafka\Conf::setDefaultTopicConf() is deprecated in %s%econf_setDefaultTopicConf.php on line 9
 
-Warning: RdKafka\Conf::setDefaultTopicConf() expects parameter 1 to be RdKafka\TopicConf, object given in %s/conf_setDefaultTopicConf.php on line 9
+Warning: RdKafka\Conf::setDefaultTopicConf() expects parameter 1 to be RdKafka\TopicConf, object given in %s%econf_setDefaultTopicConf.php on line 9
 


### PR DESCRIPTION
The directory separator is `\` on Windows, so the test case fails.
Therefore we're using `%e` to check for the separator.