### PR TITLE
remove header destroy

### DIFF
--- a/topic.c
+++ b/topic.c
@@ -619,6 +619,7 @@ PHP_METHOD(RdKafka__ProducerTopic, producev)
     );
 
     if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
+        rd_kafka_headers_destroy(headers);
         zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err TSRMLS_CC);
         return;
     }

--- a/topic.c
+++ b/topic.c
@@ -618,8 +618,6 @@ PHP_METHOD(RdKafka__ProducerTopic, producev)
             RD_KAFKA_V_END
     );
 
-    rd_kafka_headers_destroy(headers);
-
     if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
         zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err TSRMLS_CC);
         return;


### PR DESCRIPTION
was reported by @Steveb-p during testing, i was able to reproduce that and it seems,
that it fails (core dumped) when doing:
```
rd_malloc
```
somewhere, from what i understood, it is because the produce_request is not created yet and i freed the header to early. The error happens shortly after freeing the headers (not immediately) this is what lead to my conclusion.