### PR TITLE
Issue warns

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -823,7 +823,7 @@ PHP_METHOD(RdKafka__TopicConf, setPartitioner)
             break;
 #endif
         default:
-            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "Invalid partitioner given", partitioner TSRMLS_CC);
+            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "Invalid partitioner given" TSRMLS_CC);
             return;
     }
 

--- a/conf.c
+++ b/conf.c
@@ -792,7 +792,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__TopicConf, setPartitioner)
 {
     kafka_conf_object *intern;
-    long id;
+    zend_long id;
     int32_t (*partitioner) (const rd_kafka_topic_t * rkt, const void * keydata, size_t keylen, int32_t partition_cnt, void * rkt_opaque, void * msg_opaque);
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &id) == FAILURE) {

--- a/fun.c
+++ b/fun.c
@@ -103,7 +103,7 @@ PHP_FUNCTION(rd_kafka_get_err_descs)
  */
 PHP_FUNCTION(rd_kafka_err2str)
 {
-    long err;
+    zend_long err;
     const char *errstr;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &err) == FAILURE) {
@@ -134,7 +134,7 @@ PHP_FUNCTION(rd_kafka_errno)
  * Converts `errno` to a rdkafka error code */
 PHP_FUNCTION(rd_kafka_errno2err)
 {
-    long errnox;
+    zend_long errnox;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &errnox) == FAILURE) {
         return;
@@ -162,7 +162,7 @@ PHP_FUNCTION(rd_kafka_thread_cnt)
  */
 PHP_FUNCTION(rd_kafka_offset_tail)
 {
-    long cnt;
+    zend_long cnt;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &cnt) == FAILURE) {
         return;

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -380,7 +380,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__KafkaConsumer, consume)
 {
     object_intern *intern;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_message_t *rkmessage, rkmessage_tmp = {0};
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout_ms) == FAILURE) {
@@ -549,7 +549,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, getMetadata)
 {
     zend_bool all_topics;
     zval *only_zrkt;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_resp_err_t err;
     object_intern *intern;
     const rd_kafka_metadata_t *metadata;
@@ -653,7 +653,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__KafkaConsumer, getCommittedOffsets)
 {
     HashTable *htopars = NULL;
-    long timeout_ms;
+    zend_long timeout_ms;
     object_intern *intern;
     rd_kafka_resp_err_t err;
     rd_kafka_topic_partition_list_t *topics;
@@ -737,7 +737,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, offsetsForTimes)
     HashTable *htopars = NULL;
     object_intern *intern;
     rd_kafka_topic_partition_list_t *topicPartitions;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_resp_err_t err;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "hl", &htopars, &timeout_ms) == FAILURE) {
@@ -782,7 +782,8 @@ PHP_METHOD(RdKafka__KafkaConsumer, queryWatermarkOffsets)
     object_intern *intern;
     char *topic;
     arglen_t topic_length;
-    long partition, low, high, timeout;
+    long low, high;
+    zend_long partition, timeout;
     zval *lowResult, *highResult;
     rd_kafka_resp_err_t err;
 

--- a/php_rdkafka_priv.h
+++ b/php_rdkafka_priv.h
@@ -117,6 +117,9 @@ static inline char *rdkafka_hash_get_current_key_ex(HashTable *ht, HashPosition 
 #define RDKAFKA_ZVAL_STRING(zv, str) ZVAL_STRING(zv, str)
 #else /* PHP < 7 */
 
+typedef long zend_long;
+#define ZEND_LONG_FMT "%ld"
+
 typedef int arglen_t;
 
 #define STORE_OBJECT(retval, intern, dtor, free, clone) do { \

--- a/queue.c
+++ b/queue.c
@@ -90,7 +90,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Queue, consume)
 {
     kafka_queue_object *intern;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_message_t *message;
     rd_kafka_resp_err_t err;
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -362,7 +362,7 @@ PHP_METHOD(RdKafka__Kafka, getMetadata)
 {
     zend_bool all_topics;
     zval *only_zrkt;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_resp_err_t err;
     kafka_object *intern;
     const rd_kafka_metadata_t *metadata;
@@ -405,7 +405,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Kafka, setLogLevel)
 {
     kafka_object *intern;
-    long level;
+    zend_long level;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &level) == FAILURE) {
         return;
@@ -527,7 +527,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Kafka, poll)
 {
     kafka_object *intern;
-    long timeout;
+    zend_long timeout;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout) == FAILURE) {
         return;
@@ -552,7 +552,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Kafka, flush)
 {
     kafka_object *intern;
-    long timeout;
+    zend_long timeout;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout) == FAILURE) {
         return;
@@ -578,7 +578,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Kafka, purge)
 {
     kafka_object *intern;
-    long purge_flags;
+    zend_long purge_flags;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &purge_flags) == FAILURE) {
         return;
@@ -610,7 +610,8 @@ PHP_METHOD(RdKafka__Kafka, queryWatermarkOffsets)
     kafka_object *intern;
     char *topic;
     arglen_t topic_length;
-    long partition, low, high, timeout;
+    long low, high;
+    zend_long partition, timeout;
     zval *lowResult, *highResult;
     rd_kafka_resp_err_t err;
 
@@ -649,7 +650,7 @@ PHP_METHOD(RdKafka__Kafka, offsetsForTimes)
     HashTable *htopars = NULL;
     kafka_object *intern;
     rd_kafka_topic_partition_list_t *topicPartitions;
-    long timeout_ms;
+    zend_long timeout_ms;
     rd_kafka_resp_err_t err;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "hl", &htopars, &timeout_ms) == FAILURE) {
@@ -689,7 +690,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__Kafka, setLogger)
 {
     kafka_object *intern;
-    long id;
+    zend_long id;
     void (*logger) (const rd_kafka_t * rk, int level, const char *fac, const char *buf);
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &id) == FAILURE) {

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -54,10 +54,6 @@ typedef struct _toppar {
     int32_t             partition;
 } toppar;
 
-static const zend_function_entry empty_function_entries[] = {
-    PHP_FE_END
-};
-
 static zend_object_handlers kafka_object_handlers;
 zend_object_handlers kafka_default_object_handlers;
 
@@ -239,9 +235,6 @@ int is_consuming_toppar(kafka_object * intern, rd_kafka_topic_t * rkt, int32_t p
 }
 
 /* {{{ private constructor */
-ZEND_BEGIN_ARG_INFO_EX(arginfo_kafka___private_construct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 PHP_METHOD(RdKafka, __construct)
 {
     zend_throw_exception(NULL, "Private constructor", 0 TSRMLS_CC);

--- a/topic.c
+++ b/topic.c
@@ -123,8 +123,8 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, consumeCallback)
 {
     php_callback cb;
-    long partition;
-    long timeout_ms;
+    zend_long partition;
+    zend_long timeout_ms;
     long result;
     kafka_topic_object *intern;
 
@@ -166,8 +166,8 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeQueueStart)
     zval *zrkqu;
     kafka_topic_object *intern;
     kafka_queue_object *queue_intern;
-    long partition;
-    long offset;
+    zend_long partition;
+    zend_long offset;
     int ret;
     rd_kafka_resp_err_t err;
     kafka_object *kafka_intern;
@@ -200,7 +200,7 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeQueueStart)
         zend_throw_exception_ex(
             ce_kafka_exception,
             0 TSRMLS_CC,
-            "%s:%ld is already being consumed by the same Consumer instance",
+            "%s:" ZEND_LONG_FMT " is already being consumed by the same Consumer instance",
             rd_kafka_topic_name(intern->rkt),
             partition
         );
@@ -230,8 +230,8 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, consumeStart)
 {
     kafka_topic_object *intern;
-    long partition;
-    long offset;
+    zend_long partition;
+    zend_long offset;
     int ret;
     rd_kafka_resp_err_t err;
     kafka_object *kafka_intern;
@@ -259,7 +259,7 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeStart)
         zend_throw_exception_ex(
             ce_kafka_exception,
             0 TSRMLS_CC,
-            "%s:%ld is already being consumed by the same Consumer instance",
+            "%s:" ZEND_LONG_FMT " is already being consumed by the same Consumer instance",
             rd_kafka_topic_name(intern->rkt),
             partition
         );
@@ -288,7 +288,7 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, consumeStop)
 {
     kafka_topic_object *intern;
-    long partition;
+    zend_long partition;
     int ret;
     rd_kafka_resp_err_t err;
     kafka_object *kafka_intern;
@@ -335,8 +335,8 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, consume)
 {
     kafka_topic_object *intern;
-    long partition;
-    long timeout_ms;
+    zend_long partition;
+    zend_long timeout_ms;
     rd_kafka_message_t *message;
     rd_kafka_resp_err_t err;
 
@@ -383,7 +383,8 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, consumeBatch)
 {
     kafka_topic_object *intern;
-    long partition, timeout_ms, batch_size, result, i;
+    zend_long partition, timeout_ms, batch_size;
+    long result, i;
     rd_kafka_message_t **rkmessages;
     rd_kafka_resp_err_t err;
 
@@ -438,8 +439,8 @@ ZEND_END_ARG_INFO()
 PHP_METHOD(RdKafka__ConsumerTopic, offsetStore)
 {
     kafka_topic_object *intern;
-    long partition;
-    long offset;
+    zend_long partition;
+    zend_long offset;
     rd_kafka_resp_err_t err;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll", &partition, &offset) == FAILURE) {
@@ -493,8 +494,8 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__ProducerTopic, produce)
 {
-    long partition;
-    long msgflags;
+    zend_long partition;
+    zend_long msgflags;
     char *payload = NULL;
     arglen_t payload_len = 0;
     char *key = NULL;
@@ -544,8 +545,8 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__ProducerTopic, producev)
 {
-    long partition;
-    long msgflags;
+    zend_long partition;
+    zend_long msgflags;
     char *payload = NULL;
     arglen_t payload_len = 0;
     char *key = NULL;
@@ -558,7 +559,7 @@ PHP_METHOD(RdKafka__ProducerTopic, producev)
     char *header_key;
     zeval *header_value;
     rd_kafka_headers_t *headers;
-    long timestamp_ms = 0;
+    zend_long timestamp_ms = 0;
     zend_bool timestamp_ms_is_null = 0;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ll|s!s!h!l!", &partition, &msgflags, &payload, &payload_len, &key, &key_len, &headersParam, &timestamp_ms, &timestamp_ms_is_null) == FAILURE) {

--- a/topic.c
+++ b/topic.c
@@ -384,7 +384,6 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeBatch)
 {
     kafka_topic_object *intern;
     long partition, timeout_ms, batch_size, result, i;
-    zval messages;
     rd_kafka_message_t **rkmessages;
     rd_kafka_resp_err_t err;
 

--- a/topic.c
+++ b/topic.c
@@ -200,7 +200,7 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeQueueStart)
         zend_throw_exception_ex(
             ce_kafka_exception,
             0 TSRMLS_CC,
-            "%s:%d is already being consumed by the same Consumer instance",
+            "%s:%ld is already being consumed by the same Consumer instance",
             rd_kafka_topic_name(intern->rkt),
             partition
         );
@@ -259,7 +259,7 @@ PHP_METHOD(RdKafka__ConsumerTopic, consumeStart)
         zend_throw_exception_ex(
             ce_kafka_exception,
             0 TSRMLS_CC,
-            "%s:%d is already being consumed by the same Consumer instance",
+            "%s:%ld is already being consumed by the same Consumer instance",
             rd_kafka_topic_name(intern->rkt),
             partition
         );

--- a/topic_partition.c
+++ b/topic_partition.c
@@ -202,8 +202,8 @@ PHP_METHOD(RdKafka__TopicPartition, __construct)
 {
     char *topic;
     arglen_t topic_len;
-    long partition;
-    long offset = 0;
+    zend_long partition;
+    zend_long offset = 0;
     zend_error_handling error_handling;
 
     zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
@@ -310,7 +310,7 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__TopicPartition, setPartition)
 {
-    long partition;
+    zend_long partition;
     object_intern *intern;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &partition) == FAILURE) {
@@ -360,7 +360,7 @@ ZEND_END_ARG_INFO()
 
 PHP_METHOD(RdKafka__TopicPartition, setOffset)
 {
-    long offset;
+    zend_long offset;
     object_intern *intern;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &offset) == FAILURE) {


### PR DESCRIPTION
Remaining warnings: [-Wdeprecated-declarations]

* `rd_kafka_errno2err`
* `rd_kafka_set_logger`

About [-WFormat]

The call to zend_parse_parameter for l have to use a `zend_long `in 7+ (not a `long`), and for consistency use `ZEND_LONG_FMT `(not `%ld`)

