### PR TITLE
Cast LOG_DEBUG to string in sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ servers) to it:
 ``` php
 <?php
 $conf = new RdKafka\Conf();
-$conf->set('log_level', LOG_DEBUG);
+$conf->set('log_level', (string) LOG_DEBUG);
 $conf->set('debug', 'all');
 $rk = new RdKafka\Producer($conf);
 $rk->addBrokers("10.0.0.1:9092,10.0.0.2:9092");


### PR DESCRIPTION
All configuration parameters passed to librdkafka should be strings.
Failure to do so results in:
```
TypeError : RdKafka\Conf::set() expects parameter 2 to be string, integer given
```