### PR TITLE
Fix RD_KAFKA_RESP_ERR__TIMED_OUT when there are no more messages

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -381,7 +381,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, consume)
 {
     object_intern *intern;
     zend_long timeout_ms;
-    rd_kafka_message_t *rkmessage, rkmessage_tmp = {0};
+    rd_kafka_message_t *rkmessage;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout_ms) == FAILURE) {
         return;
@@ -395,15 +395,12 @@ PHP_METHOD(RdKafka__KafkaConsumer, consume)
     rkmessage = rd_kafka_consumer_poll(intern->rk, timeout_ms);
 
     if (!rkmessage) {
-        rkmessage_tmp.err = RD_KAFKA_RESP_ERR__TIMED_OUT;
-        rkmessage = &rkmessage_tmp;
+        RETURN_NULL()
     }
 
     kafka_message_new(return_value, rkmessage TSRMLS_CC);
 
-    if (rkmessage != &rkmessage_tmp) {
-        rd_kafka_message_destroy(rkmessage);
-    }
+    rd_kafka_message_destroy(rkmessage);
 }
 /* }}} */
 

--- a/tests/null_on_no_message.phpt
+++ b/tests/null_on_no_message.phpt
@@ -1,0 +1,69 @@
+--TEST--
+RdKafka\Conf
+--SKIPIF--
+<?php
+RD_KAFKA_VERSION >= 0x090000 || die("skip librdkafka too old");
+require __DIR__ . '/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+$topic = $producer->newTopic($topicName);
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i");
+    $producer->poll(0);
+}
+
+while ($producer->getOutQLen()) {
+    $producer->poll(50);
+}
+
+$conf = new RdKafka\Conf();
+
+$conf->set('auto.offset.reset', 'earliest');
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
+$conf->set('enable.partition.eof', 'false');
+
+$consumer = new RdKafka\KafkaConsumer($conf);
+$consumer->subscribe([$topicName]);
+
+$listeningEnd = time() + 15;
+$i = 0;
+while ($i < 10 && time() < $listeningEnd) {
+    $msg = $consumer->consume(500);
+
+    if ($msg === null) {
+        continue;
+    }
+
+    if (RD_KAFKA_RESP_ERR_NO_ERROR !== $msg->err) {
+        throw new Exception($msg->errstr(), $msg->err);
+    }
+
+    echo $msg->payload, "\n";
+    $i++;
+
+    $consumer->commit($msg);
+}
+
+--EXPECT--
+message 0
+message 1
+message 2
+message 3
+message 4
+message 5
+message 6
+message 7
+message 8
+message 9


### PR DESCRIPTION
This fixes #343 and fixes #342. 

Allows for long-running scripts to continue consuming messages from broker, while not making user think that there is a connectivity error. In such case librdkafka will populate `err` property anyway.

This allows long-running scripts to continue uninterrupted, without falsely reporting that a timeout is reached while in reality there simply was no new message. This is important even in cases where `enabled.partition.eof` is set to `true`, as `EOF` is emitted only once and then consumer will start returning `null` when `rd_kafka_consumer_poll` is invoked, leading to errors described in fixed issues.

I believe it should not have any memory leaks by introducing those changes, but my local development environment (docker) isn't built from source and doesn't have the required debug symbols, so I'm relying on travis tests to spot them (since I'm no expert in PHP extensions).