### PR TITLE
remove addBroker from tests

### DIFF
--- a/tests/allow_null_payload.phpt
+++ b/tests/allow_null_payload.phpt
@@ -21,8 +21,7 @@ while ($producer->getOutQLen() > 0) {
     $producer->poll(50);
 }
 
-$consumer = new RdKafka\Consumer();
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
+$consumer = new RdKafka\Consumer($conf);
 
 $topic = $consumer->newTopic($topicName);
 $topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);

--- a/tests/allow_null_payload.phpt
+++ b/tests/allow_null_payload.phpt
@@ -7,10 +7,12 @@ require __DIR__ . '/integration-tests-check.php';
 <?php
 require __DIR__ . '/integration-tests-check.php';
 
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
 $topicName = sprintf('test_rdkafka_%s', uniqid());
 
-$producer = new RdKafka\Producer();
-$producer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
+$producer = new RdKafka\Producer($conf);
 $topic = $producer->newTopic($topicName);
 
 $topic->produce(0, 0, NULL, 'message_key_1');

--- a/tests/allow_null_payload_and_key.phpt
+++ b/tests/allow_null_payload_and_key.phpt
@@ -7,10 +7,12 @@ require __DIR__ . '/integration-tests-check.php';
 <?php
 require __DIR__ . '/integration-tests-check.php';
 
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
 $topicName = sprintf('test_rdkafka_%s', uniqid());
 
-$producer = new RdKafka\Producer();
-$producer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
+$producer = new RdKafka\Producer($conf);
 $topic = $producer->newTopic($topicName);
 
 $topic->produce(0, 0);
@@ -19,8 +21,7 @@ while ($producer->getOutQLen() > 0) {
     $producer->poll(50);
 }
 
-$consumer = new RdKafka\Consumer();
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
+$consumer = new RdKafka\Consumer($conf);
 
 $topic = $consumer->newTopic($topicName);
 $topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);

--- a/tests/bug115.phpt
+++ b/tests/bug115.phpt
@@ -23,11 +23,11 @@ $conf->setDrMsgCb(function ($producer, $msg) use (&$delivered) {
     }
     $delivered++;
 });
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 
 $topicName = sprintf("test_rdkafka_%s", uniqid());
 
 $consumer = new RdKafka\Consumer($conf);
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
 
 $topic = $consumer->newTopic($topicName);
 $topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);

--- a/tests/bug74.phpt
+++ b/tests/bug74.phpt
@@ -4,7 +4,7 @@ Bug 74
 <?php
 
 $conf = new RdKafka\Conf();
-$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->set('metadata.broker.list', 'localhost:9092');
 
 $consumer = new RdKafka\Consumer($conf);
 $topic = $consumer->newTopic("batman", null);

--- a/tests/bug74.phpt
+++ b/tests/bug74.phpt
@@ -3,10 +3,13 @@ Bug 74
 --FILE--
 <?php
 
-$consumer = new RdKafka\Consumer(null);
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$consumer = new RdKafka\Consumer($conf);
 $topic = $consumer->newTopic("batman", null);
 
-$producer = new RdKafka\Producer(null);
+$producer = new RdKafka\Producer($conf);
 
 if (class_exists('RdKafka\TopicPartition')) {
     $tp = new RdKafka\TopicPartition("batman", 0, null);

--- a/tests/bug88.phpt
+++ b/tests/bug88.phpt
@@ -8,7 +8,7 @@ if (!class_exists("RdKafka\\KafkaConsumer")) {
 --FILE--
 <?php
 $conf = new RdKafka\Conf();
-if (RD_KAFKA_VERSION >= 0x150000) {
+if (RD_KAFKA_VERSION <= 0x150000) {
     $conf->set('boostrap.servers', '127.0.0.1:9092');
 } else {
     $conf->set('metadata.broker.list', '127.0.0.1:9092');

--- a/tests/bug88.phpt
+++ b/tests/bug88.phpt
@@ -8,11 +8,8 @@ if (!class_exists("RdKafka\\KafkaConsumer")) {
 --FILE--
 <?php
 $conf = new RdKafka\Conf();
-if (RD_KAFKA_VERSION >= 0x01050001) {
-    $conf->set('boostrap.servers', '127.0.0.1:9092');
-} else {
-    $conf->set('metadata.broker.list', '127.0.0.1:9092');
-}
+$conf->set('metadata.broker.list', '127.0.0.1:9092');
+
 $consumer = new RdKafka\KafkaConsumer($conf);
 echo "ok\n";
 --EXPECTF--

--- a/tests/bug88.phpt
+++ b/tests/bug88.phpt
@@ -8,7 +8,11 @@ if (!class_exists("RdKafka\\KafkaConsumer")) {
 --FILE--
 <?php
 $conf = new RdKafka\Conf();
-$conf->set('metadata.broker.list', '127.0.0.1:9092');
+if (RD_KAFKA_VERSION >= 0x150000) {
+    $conf->set('boostrap.servers', '127.0.0.1:9092');
+} else {
+    $conf->set('metadata.broker.list', '127.0.0.1:9092');
+}
 $consumer = new RdKafka\KafkaConsumer($conf);
 echo "ok\n";
 --EXPECTF--

--- a/tests/bug88.phpt
+++ b/tests/bug88.phpt
@@ -8,7 +8,7 @@ if (!class_exists("RdKafka\\KafkaConsumer")) {
 --FILE--
 <?php
 $conf = new RdKafka\Conf();
-if (RD_KAFKA_VERSION <= 0x150000) {
+if (RD_KAFKA_VERSION >= 0x01050001) {
     $conf->set('boostrap.servers', '127.0.0.1:9092');
 } else {
     $conf->set('metadata.broker.list', '127.0.0.1:9092');

--- a/tests/bugConfSetArgument.phpt
+++ b/tests/bugConfSetArgument.phpt
@@ -13,7 +13,7 @@ class TestBug extends RdKafka\Conf
 
 $conf = new TestBug();
 
-if (RD_KAFKA_VERSION <= 0x150000) {
+if (RD_KAFKA_VERSION >= 0x01050001) {
     $conf->set('bootstrap.servers', '127.0.0.1');
 } else {
     $conf->set('metadata.broker.list', '127.0.0.1');

--- a/tests/bugConfSetArgument.phpt
+++ b/tests/bugConfSetArgument.phpt
@@ -13,7 +13,7 @@ class TestBug extends RdKafka\Conf
 
 $conf = new TestBug();
 
-if (RD_KAFKA_VERSION >= 0x150000) {
+if (RD_KAFKA_VERSION <= 0x150000) {
     $conf->set('bootstrap.servers', '127.0.0.1');
 } else {
     $conf->set('metadata.broker.list', '127.0.0.1');

--- a/tests/bugConfSetArgument.phpt
+++ b/tests/bugConfSetArgument.phpt
@@ -12,12 +12,8 @@ class TestBug extends RdKafka\Conf
 }
 
 $conf = new TestBug();
+$conf->set('metadata.broker.list', '127.0.0.1');
 
-if (RD_KAFKA_VERSION >= 0x01050001) {
-    $conf->set('bootstrap.servers', '127.0.0.1');
-} else {
-    $conf->set('metadata.broker.list', '127.0.0.1');
-}
 echo "done" . PHP_EOL;
 --EXPECT--
 done

--- a/tests/bugConfSetArgument.phpt
+++ b/tests/bugConfSetArgument.phpt
@@ -12,7 +12,12 @@ class TestBug extends RdKafka\Conf
 }
 
 $conf = new TestBug();
-$conf->set('metadata.broker.list', '127.0.0.1');
+
+if (RD_KAFKA_VERSION >= 0x150000) {
+    $conf->set('bootstrap.servers', '127.0.0.1');
+} else {
+    $conf->set('metadata.broker.list', '127.0.0.1');
+}
 echo "done" . PHP_EOL;
 --EXPECT--
 done

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -12,7 +12,11 @@ require __DIR__ . '/integration-tests-check.php';
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+if (RD_KAFKA_VERSION >= 0x150000) {
+    $conf->set('bootstrap.servers', getenv('TEST_KAFKA_BROKERS'));
+} else {
+    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+}
 $conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
 
 $producer = new RdKafka\Producer($conf);
@@ -35,7 +39,11 @@ sleep(1);
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+if (RD_KAFKA_VERSION >= 0x150000) {
+    $conf->set('boostrap.servers', getenv('TEST_KAFKA_BROKERS'));
+} else {
+    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+}
 $conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
 $conf->set('statistics.interval.ms', 10);
 

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -12,7 +12,7 @@ require __DIR__ . '/integration-tests-check.php';
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION >= 0x150000) {
+if (RD_KAFKA_VERSION <= 0x150000) {
     $conf->set('bootstrap.servers', getenv('TEST_KAFKA_BROKERS'));
 } else {
     $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
@@ -39,7 +39,7 @@ sleep(1);
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION >= 0x150000) {
+if (RD_KAFKA_VERSION <= 0x150000) {
     $conf->set('boostrap.servers', getenv('TEST_KAFKA_BROKERS'));
 } else {
     $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -12,7 +12,7 @@ require __DIR__ . '/integration-tests-check.php';
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION <= 0x150000) {
+if (RD_KAFKA_VERSION >= 0x01050001) {
     $conf->set('bootstrap.servers', getenv('TEST_KAFKA_BROKERS'));
 } else {
     $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
@@ -39,7 +39,7 @@ sleep(1);
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION <= 0x150000) {
+if (RD_KAFKA_VERSION >= 0x01050001) {
     $conf->set('boostrap.servers', getenv('TEST_KAFKA_BROKERS'));
 } else {
     $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -36,11 +36,7 @@ sleep(1);
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION >= 0x01050001) {
-    $conf->set('boostrap.servers', getenv('TEST_KAFKA_BROKERS'));
-} else {
-    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
-}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 $conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
 $conf->set('statistics.interval.ms', 10);
 

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -12,11 +12,8 @@ require __DIR__ . '/integration-tests-check.php';
 $conf = new RdKafka\Conf();
 
 $conf->set('auto.offset.reset', 'earliest');
-if (RD_KAFKA_VERSION >= 0x01050001) {
-    $conf->set('bootstrap.servers', getenv('TEST_KAFKA_BROKERS'));
-} else {
-    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
-}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
 $conf->set('group.id', sprintf("test_rdkafka_group_%s", uniqid()));
 
 $producer = new RdKafka\Producer($conf);

--- a/tests/message_headers.phpt
+++ b/tests/message_headers.phpt
@@ -21,13 +21,9 @@ $conf->setDrMsgCb(function ($producer, $msg) use (&$delivered) {
     }
     $delivered++;
 });
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 
 $producer = new RdKafka\Producer($conf);
-
-if ($producer->addBrokers(getenv('TEST_KAFKA_BROKERS')) < 1) {
-    echo "Failed adding brokers\n";
-    exit;
-}
 
 $topicName = sprintf("test_rdkafka_%s", uniqid());
 
@@ -62,7 +58,6 @@ while ($producer->getOutQLen()) {
 printf("%d messages delivered\n", $delivered);
 
 $consumer = new RdKafka\Consumer($conf);
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
 
 $topic = $consumer->newTopic($topicName);
 $topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);

--- a/tests/produce_consume.phpt
+++ b/tests/produce_consume.phpt
@@ -23,13 +23,9 @@ $conf->setDrMsgCb(function ($producer, $msg) use (&$delivered) {
     }
     $delivered++;
 });
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 
 $producer = new RdKafka\Producer($conf);
-
-if ($producer->addBrokers(getenv('TEST_KAFKA_BROKERS')) < 1) {
-    echo "Failed adding brokers\n";
-    exit;
-}
 
 $topicName = sprintf("test_rdkafka_%s", uniqid());
 
@@ -51,7 +47,6 @@ while ($producer->getOutQLen()) {
 printf("%d messages delivered\n", $delivered);
 
 $consumer = new RdKafka\Consumer($conf);
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
 
 $topic = $consumer->newTopic($topicName);
 $topic->consumeStart(0, RD_KAFKA_OFFSET_BEGINNING);
@@ -64,11 +59,11 @@ while (true) {
     if (!$msg || $msg->err === RD_KAFKA_RESP_ERR__PARTITION_EOF) {
         break;
     }
-    
+
     if (RD_KAFKA_RESP_ERR_NO_ERROR !== $msg->err) {
         throw new Exception($msg->errstr(), $msg->err);
     }
-    
+
     printf("Got message: %s\n", $msg->payload);
 }
 --EXPECT--

--- a/tests/produce_consume_queue.phpt
+++ b/tests/produce_consume_queue.phpt
@@ -25,13 +25,9 @@ $conf->setDrMsgCb(function ($producer, $msg) use (&$delivered) {
     }
     $delivered++;
 });
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 
 $producer = new RdKafka\Producer($conf);
-
-if ($producer->addBrokers(getenv('TEST_KAFKA_BROKERS')) < 1) {
-    echo "Failed adding brokers\n";
-    exit;
-}
 
 $topicNames = [
     sprintf("test_rdkafka_0_%s", uniqid()),
@@ -58,7 +54,6 @@ while ($producer->getOutQLen()) {
 printf("%d messages delivered\n", $delivered);
 
 $consumer = new RdKafka\Consumer($conf);
-$consumer->addBrokers(getenv('TEST_KAFKA_BROKERS'));
 
 $queue = $consumer->newQueue();
 


### PR DESCRIPTION
It seems `addBroker` is not favourited anymore and brokers should be in config.
Root cause was tests failing on `librdkafka:master`.