### PR TITLE
Add debug to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -19,6 +19,4 @@ $conf = new RdKafka\Conf();
 // Add the two settings below for a more verbose output
 $conf->set('log_level', (string) LOG_DEBUG);
 $conf->set('debug', 'all');
-$rk = new RdKafka\Producer($conf);
-$rk->addBrokers("10.0.0.1:9092,10.0.0.2:9092");
 ```

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -11,3 +11,13 @@ Please always include the following in an issue, so we can help faster:
  * librdkafka version:
  * php-rdkafka version:
  * kafka version:
+
+If possible, add debug logs from librdkafka, which you can obtain by adjusting your configuration:
+```php
+<?php
+$conf = new RdKafka\Conf();
+$conf->set('log_level', (string) LOG_DEBUG);
+$conf->set('debug', 'all');
+$rk = new RdKafka\Producer($conf);
+$rk->addBrokers("10.0.0.1:9092,10.0.0.2:9092");
+```

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -16,6 +16,7 @@ If possible, add debug logs from librdkafka, which you can obtain by adjusting y
 ```php
 <?php
 $conf = new RdKafka\Conf();
+// Add the two settings below for a more verbose output
 $conf->set('log_level', (string) LOG_DEBUG);
 $conf->set('debug', 'all');
 $rk = new RdKafka\Producer($conf);


### PR DESCRIPTION
People often have issues that can be resolved only when looking at php-rdkafka logs with librdkafka in high verbosity mode.  
This adds the relevant commands to issue template so that more people start by looking at them, possibly auto-resolving their problem.