### PR TITLE
Drop TSRMLS

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -38,7 +38,7 @@ zend_class_entry * ce_kafka_topic_conf;
 
 static zend_object_handlers handlers;
 
-static void kafka_conf_callback_dtor(kafka_conf_callback *cb TSRMLS_DC) /* {{{ */
+static void kafka_conf_callback_dtor(kafka_conf_callback *cb) /* {{{ */
 {
     if (cb) {
         zval_ptr_dtor(&cb->fci.function_name);
@@ -46,25 +46,25 @@ static void kafka_conf_callback_dtor(kafka_conf_callback *cb TSRMLS_DC) /* {{{ *
     }
 } /* }}} */
 
-void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs TSRMLS_DC) /* {{{ */
+void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs) /* {{{ */
 {
-    kafka_conf_callback_dtor(cbs->error TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->error);
     cbs->error = NULL;
-    kafka_conf_callback_dtor(cbs->rebalance TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->rebalance);
     cbs->rebalance = NULL;
-    kafka_conf_callback_dtor(cbs->dr_msg TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->dr_msg);
     cbs->dr_msg = NULL;
-    kafka_conf_callback_dtor(cbs->stats TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->stats);
     cbs->stats = NULL;
-    kafka_conf_callback_dtor(cbs->consume TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->consume);
     cbs->consume = NULL;
-    kafka_conf_callback_dtor(cbs->offset_commit TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->offset_commit);
     cbs->offset_commit = NULL;
-    kafka_conf_callback_dtor(cbs->log TSRMLS_CC);
+    kafka_conf_callback_dtor(cbs->log);
     cbs->log = NULL;
 } /* }}} */
 
-static void kafka_conf_callback_copy(kafka_conf_callback **to, kafka_conf_callback *from TSRMLS_DC) /* {{{ */
+static void kafka_conf_callback_copy(kafka_conf_callback **to, kafka_conf_callback *from) /* {{{ */
 {
     if (from) {
         *to = emalloc(sizeof(**to));
@@ -77,18 +77,18 @@ static void kafka_conf_callback_copy(kafka_conf_callback **to, kafka_conf_callba
     }
 } /* }}} */
 
-void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *from TSRMLS_DC) /* {{{ */
+void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *from) /* {{{ */
 {
-    kafka_conf_callback_copy(&to->error, from->error TSRMLS_CC);
-    kafka_conf_callback_copy(&to->rebalance, from->rebalance TSRMLS_CC);
-    kafka_conf_callback_copy(&to->dr_msg, from->dr_msg TSRMLS_CC);
-    kafka_conf_callback_copy(&to->stats, from->stats TSRMLS_CC);
-    kafka_conf_callback_copy(&to->consume, from->consume TSRMLS_CC);
-    kafka_conf_callback_copy(&to->offset_commit, from->offset_commit TSRMLS_CC);
-    kafka_conf_callback_copy(&to->log, from->log TSRMLS_CC);
+    kafka_conf_callback_copy(&to->error, from->error);
+    kafka_conf_callback_copy(&to->rebalance, from->rebalance);
+    kafka_conf_callback_copy(&to->dr_msg, from->dr_msg);
+    kafka_conf_callback_copy(&to->stats, from->stats);
+    kafka_conf_callback_copy(&to->consume, from->consume);
+    kafka_conf_callback_copy(&to->offset_commit, from->offset_commit);
+    kafka_conf_callback_copy(&to->log, from->log);
 } /* }}} */
 
-static void kafka_conf_free(zend_object *object TSRMLS_DC) /* {{{ */
+static void kafka_conf_free(zend_object *object) /* {{{ */
 {
     kafka_conf_object *intern = get_custom_object(kafka_conf_object, object);
 
@@ -97,7 +97,7 @@ static void kafka_conf_free(zend_object *object TSRMLS_DC) /* {{{ */
             if (intern->u.conf) {
                 rd_kafka_conf_destroy(intern->u.conf);
             }
-            kafka_conf_callbacks_dtor(&intern->cbs TSRMLS_CC);
+            kafka_conf_callbacks_dtor(&intern->cbs);
             break;
         case KAFKA_TOPIC_CONF:
             if (intern->u.topic_conf) {
@@ -106,19 +106,19 @@ static void kafka_conf_free(zend_object *object TSRMLS_DC) /* {{{ */
             break;
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value kafka_conf_new(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value kafka_conf_new(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     kafka_conf_object *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
     STORE_OBJECT(retval, intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, kafka_conf_free, NULL);
@@ -128,12 +128,12 @@ static zend_object_value kafka_conf_new(zend_class_entry *class_type TSRMLS_DC) 
 }
 /* }}} */
 
-kafka_conf_object * get_kafka_conf_object(zval *zconf TSRMLS_DC)
+kafka_conf_object * get_kafka_conf_object(zval *zconf)
 {
     kafka_conf_object *oconf = get_custom_object_zval(kafka_conf_object, zconf);
 
     if (!oconf->type) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Conf::__construct() has not been called" TSRMLS_CC);
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Conf::__construct() has not been called");
         return NULL;
     }
 
@@ -162,7 +162,7 @@ static void kafka_conf_error_cb(rd_kafka_t *rk, int err, const char *reason, voi
     ZVAL_LONG(P_ZEVAL(args[1]), err);
     RDKAFKA_ZVAL_STRING(P_ZEVAL(args[2]), reason);
 
-    rdkafka_call_function(&cbs->error->fci, &cbs->error->fcc, NULL, 3, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->error->fci, &cbs->error->fcc, NULL, 3, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -187,9 +187,9 @@ static void kafka_conf_dr_msg_cb(rd_kafka_t *rk, const rd_kafka_message_t *msg, 
     MAKE_STD_ZEVAL(args[1]);
 
     KAFKA_ZVAL_ZVAL(P_ZEVAL(args[0]), &cbs->zrk, 1, 0);
-    kafka_message_new(P_ZEVAL(args[1]), msg TSRMLS_CC);
+    kafka_message_new(P_ZEVAL(args[1]), msg);
 
-    rdkafka_call_function(&cbs->dr_msg->fci, &cbs->dr_msg->fcc, NULL, 2, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->dr_msg->fci, &cbs->dr_msg->fcc, NULL, 2, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -217,7 +217,7 @@ static int kafka_conf_stats_cb(rd_kafka_t *rk, char *json, size_t json_len, void
     RDKAFKA_ZVAL_STRING(P_ZEVAL(args[1]), json);
     ZVAL_LONG(P_ZEVAL(args[2]), json_len);
 
-    rdkafka_call_function(&cbs->stats->fci, &cbs->stats->fcc, NULL, 3, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->stats->fci, &cbs->stats->fcc, NULL, 3, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -240,7 +240,7 @@ static void kafka_conf_rebalance_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, rd_
         err = rd_kafka_assign(rk, NULL);
 
         if (err != RD_KAFKA_RESP_ERR_NO_ERROR) {
-            zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err TSRMLS_CC);
+            zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err);
             return;
         }
 
@@ -253,9 +253,9 @@ static void kafka_conf_rebalance_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err, rd_
 
     KAFKA_ZVAL_ZVAL(P_ZEVAL(args[0]), &cbs->zrk, 1, 0);
     ZVAL_LONG(P_ZEVAL(args[1]), err);
-    kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions TSRMLS_CC);
+    kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions);
 
-    rdkafka_call_function(&cbs->rebalance->fci, &cbs->rebalance->fcc, NULL, 3, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->rebalance->fci, &cbs->rebalance->fcc, NULL, 3, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -279,11 +279,11 @@ static void kafka_conf_consume_cb(rd_kafka_message_t *msg, void *opaque)
     MAKE_STD_ZEVAL(args[0]);
     MAKE_STD_ZEVAL(args[1]);
 
-    kafka_message_new(P_ZEVAL(args[0]), msg TSRMLS_CC);
+    kafka_message_new(P_ZEVAL(args[0]), msg);
     KAFKA_ZVAL_ZVAL(P_ZEVAL(args[1]), &cbs->zrk, 1, 0);
 
 
-    rdkafka_call_function(&cbs->consume->fci, &cbs->consume->fcc, NULL, 2, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->consume->fci, &cbs->consume->fcc, NULL, 2, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -309,9 +309,9 @@ static void kafka_conf_offset_commit_cb(rd_kafka_t *rk, rd_kafka_resp_err_t err,
 
     KAFKA_ZVAL_ZVAL(P_ZEVAL(args[0]), &cbs->zrk, 1, 0);
     ZVAL_LONG(P_ZEVAL(args[1]), err);
-    kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions TSRMLS_CC);
+    kafka_topic_partition_list_to_array(P_ZEVAL(args[2]), partitions);
 
-    rdkafka_call_function(&cbs->offset_commit->fci, &cbs->offset_commit->fcc, NULL, 3, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->offset_commit->fci, &cbs->offset_commit->fcc, NULL, 3, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -339,7 +339,7 @@ static void kafka_conf_log_cb(const rd_kafka_t *rk, int level, const char *facil
     RDKAFKA_ZVAL_STRING(P_ZEVAL(args[2]), facility);
     RDKAFKA_ZVAL_STRING(P_ZEVAL(args[3]), message);
 
-    rdkafka_call_function(&cbs->log->fci, &cbs->log->fcc, NULL, 4, args TSRMLS_CC);
+    rdkafka_call_function(&cbs->log->fci, &cbs->log->fcc, NULL, 4, args);
 
     zval_ptr_dtor(&args[0]);
     zval_ptr_dtor(&args[1]);
@@ -357,10 +357,10 @@ PHP_METHOD(RdKafka__Conf, __construct)
     kafka_conf_object *intern;
     zend_error_handling error_handling;
 
-    zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
+    zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
-        zend_restore_error_handling(&error_handling TSRMLS_CC);
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
+        zend_restore_error_handling(&error_handling);
         return;
     }
 
@@ -368,7 +368,7 @@ PHP_METHOD(RdKafka__Conf, __construct)
     intern->type = KAFKA_CONF;
     intern->u.conf = rd_kafka_conf_new();
 
-    zend_restore_error_handling(&error_handling TSRMLS_CC);
+    zend_restore_error_handling(&error_handling);
 }
 /* }}} */
 
@@ -385,11 +385,11 @@ PHP_METHOD(RdKafka__Conf, dump)
     kafka_conf_object *intern;
     size_t i;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -435,11 +435,11 @@ PHP_METHOD(RdKafka__Conf, set)
     rd_kafka_conf_res_t ret = 0;
     char errstr[512];
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "ss", &name, &name_len, &value, &value_len) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "ss", &name, &name_len, &value, &value_len) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -457,10 +457,10 @@ PHP_METHOD(RdKafka__Conf, set)
 
     switch (ret) {
         case RD_KAFKA_CONF_UNKNOWN:
-            zend_throw_exception(ce_kafka_exception, errstr, RD_KAFKA_CONF_UNKNOWN TSRMLS_CC);
+            zend_throw_exception(ce_kafka_exception, errstr, RD_KAFKA_CONF_UNKNOWN);
             return;
         case RD_KAFKA_CONF_INVALID:
-            zend_throw_exception(ce_kafka_exception, errstr, RD_KAFKA_CONF_INVALID TSRMLS_CC);
+            zend_throw_exception(ce_kafka_exception, errstr, RD_KAFKA_CONF_INVALID);
             return;
         case RD_KAFKA_CONF_OK:
             break;
@@ -481,16 +481,16 @@ PHP_METHOD(RdKafka__Conf, setDefaultTopicConf)
     kafka_conf_object *topic_conf_intern;
     rd_kafka_topic_conf_t *topic_conf;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O", &ztopic_conf, ce_kafka_topic_conf) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "O", &ztopic_conf, ce_kafka_topic_conf) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
 
-    topic_conf_intern = get_kafka_conf_object(ztopic_conf TSRMLS_CC);
+    topic_conf_intern = get_kafka_conf_object(ztopic_conf);
     if (!topic_conf_intern) {
         return;
     }
@@ -514,11 +514,11 @@ PHP_METHOD(RdKafka__Conf, setErrorCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -551,11 +551,11 @@ PHP_METHOD(RdKafka__Conf, setDrMsgCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -588,11 +588,11 @@ PHP_METHOD(RdKafka__Conf, setStatsCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -625,11 +625,11 @@ PHP_METHOD(RdKafka__Conf, setRebalanceCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -662,11 +662,11 @@ PHP_METHOD(RdKafka__Conf, setConsumeCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -699,11 +699,11 @@ PHP_METHOD(RdKafka__Conf, setOffsetCommitCb)
     zend_fcall_info_cache fcc;
     kafka_conf_object *intern;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -737,11 +737,11 @@ PHP_METHOD(RdKafka__Conf, setLogCb)
     kafka_conf_object *conf;
     char errstr[512];
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "f", &fci, &fcc) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "f", &fci, &fcc) == FAILURE) {
         return;
     }
 
-    conf = get_kafka_conf_object(getThis() TSRMLS_CC);
+    conf = get_kafka_conf_object(getThis());
     if (!conf) {
         return;
     }
@@ -768,10 +768,10 @@ PHP_METHOD(RdKafka__TopicConf, __construct)
     kafka_conf_object *intern;
     zend_error_handling error_handling;
 
-    zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling TSRMLS_CC);
+    zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
-        zend_restore_error_handling(&error_handling TSRMLS_CC);
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
+        zend_restore_error_handling(&error_handling);
         return;
     }
 
@@ -779,7 +779,7 @@ PHP_METHOD(RdKafka__TopicConf, __construct)
     intern->type = KAFKA_TOPIC_CONF;
     intern->u.topic_conf = rd_kafka_topic_conf_new();
 
-    zend_restore_error_handling(&error_handling TSRMLS_CC);
+    zend_restore_error_handling(&error_handling);
 }
 /* }}} */
 
@@ -795,11 +795,11 @@ PHP_METHOD(RdKafka__TopicConf, setPartitioner)
     zend_long id;
     int32_t (*partitioner) (const rd_kafka_topic_t * rkt, const void * keydata, size_t keylen, int32_t partition_cnt, void * rkt_opaque, void * msg_opaque);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &id) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &id) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_conf_object(getThis() TSRMLS_CC);
+    intern = get_kafka_conf_object(getThis());
     if (!intern) {
         return;
     }
@@ -823,7 +823,7 @@ PHP_METHOD(RdKafka__TopicConf, setPartitioner)
             break;
 #endif
         default:
-            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0 TSRMLS_CC, "Invalid partitioner given" TSRMLS_CC);
+            zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0, "Invalid partitioner given");
             return;
     }
 
@@ -854,7 +854,7 @@ static const zend_function_entry kafka_conf_fe[] = {
     PHP_FE_END
 };
 
-void kafka_conf_minit(TSRMLS_D)
+void kafka_conf_minit()
 {
     zend_class_entry tmpce;
 
@@ -863,10 +863,10 @@ void kafka_conf_minit(TSRMLS_D)
     set_object_handler_offset(&handlers, XtOffsetOf(kafka_conf_object, std));
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka", "Conf", kafka_conf_fe);
-    ce_kafka_conf = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce_kafka_conf = zend_register_internal_class(&tmpce);
     ce_kafka_conf->create_object = kafka_conf_new;
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka", "TopicConf", kafka_topic_conf_fe);
-    ce_kafka_topic_conf = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce_kafka_topic_conf = zend_register_internal_class(&tmpce);
     ce_kafka_topic_conf->create_object = kafka_conf_new;
 }

--- a/conf.h
+++ b/conf.h
@@ -63,11 +63,11 @@ typedef struct _kafka_conf_object {
 #endif
 } kafka_conf_object;
 
-kafka_conf_object * get_kafka_conf_object(zval *zconf TSRMLS_DC);
-void kafka_conf_minit(TSRMLS_D);
+kafka_conf_object * get_kafka_conf_object(zval *zconf);
+void kafka_conf_minit();
 
-void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs TSRMLS_DC);
-void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *from TSRMLS_DC);
+void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs);
+void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *from);
 
 extern zend_class_entry * ce_kafka_conf;
 extern zend_class_entry * ce_kafka_topic_conf;

--- a/fun.c
+++ b/fun.c
@@ -106,7 +106,7 @@ PHP_FUNCTION(rd_kafka_err2str)
     zend_long err;
     const char *errstr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &err) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &err) == FAILURE) {
         return;
     }
 
@@ -122,7 +122,7 @@ PHP_FUNCTION(rd_kafka_err2str)
  * Returns `errno` */
 PHP_FUNCTION(rd_kafka_errno)
 {
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
@@ -136,7 +136,7 @@ PHP_FUNCTION(rd_kafka_errno2err)
 {
     zend_long errnox;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &errnox) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &errnox) == FAILURE) {
         return;
     }
 
@@ -164,7 +164,7 @@ PHP_FUNCTION(rd_kafka_offset_tail)
 {
     zend_long cnt;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &cnt) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &cnt) == FAILURE) {
         return;
     }
 

--- a/kafka_consumer.h
+++ b/kafka_consumer.h
@@ -16,4 +16,4 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_kafka_consumer_minit(TSRMLS_D);
+void kafka_kafka_consumer_minit();

--- a/kafka_error_exception.c
+++ b/kafka_error_exception.c
@@ -30,16 +30,16 @@
 
 zend_class_entry * ce_kafka_error;
 
-void create_kafka_error(zval *return_value, const rd_kafka_error_t *error TSRMLS_DC) /* {{{ */
+void create_kafka_error(zval *return_value, const rd_kafka_error_t *error) /* {{{ */
 {
     object_init_ex(return_value, ce_kafka_error);
 
-    zend_update_property_string(ce_kafka_error, return_value, ZEND_STRL("message"), rd_kafka_error_name(error) TSRMLS_CC);
-    zend_update_property_long(ce_kafka_error, return_value, ZEND_STRL("code"), rd_kafka_error_code(error) TSRMLS_CC);
-    zend_update_property_string(ce_kafka_error, return_value, ZEND_STRL("error_string"), rd_kafka_error_string(error) TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("isFatal"), rd_kafka_error_is_fatal(error) TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("isRetriable"), rd_kafka_error_is_retriable(error) TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("transactionRequiresAbort"), rd_kafka_error_txn_requires_abort(error) TSRMLS_CC);
+    zend_update_property_string(ce_kafka_error, return_value, ZEND_STRL("message"), rd_kafka_error_name(error));
+    zend_update_property_long(ce_kafka_error, return_value, ZEND_STRL("code"), rd_kafka_error_code(error));
+    zend_update_property_string(ce_kafka_error, return_value, ZEND_STRL("error_string"), rd_kafka_error_string(error));
+    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("isFatal"), rd_kafka_error_is_fatal(error));
+    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("isRetriable"), rd_kafka_error_is_retriable(error));
+    zend_update_property_bool(ce_kafka_error, return_value, ZEND_STRL("transactionRequiresAbort"), rd_kafka_error_txn_requires_abort(error));
 
     Z_ADDREF_P(return_value);
 }
@@ -62,16 +62,16 @@ PHP_METHOD(RdKafka__KafkaErrorException, __construct)
     zend_bool isFatal = 0, isRetriable = 0, transactionRequiresAbort = 0;
     zend_long code = 0;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "sl|sbbb", &message, &message_length, &code, &error_string, &error_string_length, &isFatal, &isRetriable, &transactionRequiresAbort) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|sbbb", &message, &message_length, &code, &error_string, &error_string_length, &isFatal, &isRetriable, &transactionRequiresAbort) == FAILURE) {
         return;
     }
 
-    zend_update_property_string(ce_kafka_error, getThis(), ZEND_STRL("message"), message TSRMLS_CC);
-    zend_update_property_long(ce_kafka_error, getThis(), ZEND_STRL("code"), code TSRMLS_CC);
-    zend_update_property_string(ce_kafka_error, getThis(), ZEND_STRL("error_string"), error_string TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("isFatal"), isFatal TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("isRetriable"), isRetriable TSRMLS_CC);
-    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("transactionRequiresAbort"), transactionRequiresAbort TSRMLS_CC);
+    zend_update_property_string(ce_kafka_error, getThis(), ZEND_STRL("message"), message);
+    zend_update_property_long(ce_kafka_error, getThis(), ZEND_STRL("code"), code);
+    zend_update_property_string(ce_kafka_error, getThis(), ZEND_STRL("error_string"), error_string);
+    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("isFatal"), isFatal);
+    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("isRetriable"), isRetriable);
+    zend_update_property_bool(ce_kafka_error, getThis(), ZEND_STRL("transactionRequiresAbort"), transactionRequiresAbort);
 }
 /* }}} */
 
@@ -85,11 +85,11 @@ PHP_METHOD(RdKafka__KafkaErrorException, getErrorString)
 {
     zval *res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("error_string"), 0 TSRMLS_CC);
+    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("error_string"), 0);
 
     if (!res || Z_TYPE_P(res) != IS_STRING) {
         return;
@@ -115,11 +115,11 @@ PHP_METHOD(RdKafka__KafkaErrorException, isFatal)
 {
     zval *res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("isFatal"), 0 TSRMLS_CC);
+    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("isFatal"), 0);
 
 #if PHP_MAJOR_VERSION >= 7
     if (!res || (Z_TYPE_P(res) != IS_TRUE && Z_TYPE_P(res) != IS_FALSE)) {
@@ -144,11 +144,11 @@ PHP_METHOD(RdKafka__KafkaErrorException, isRetriable)
 {
     zval *res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("isRetriable"), 0 TSRMLS_CC);
+    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("isRetriable"), 0);
 
 #if PHP_MAJOR_VERSION >= 7
     if (!res || (Z_TYPE_P(res) != IS_TRUE && Z_TYPE_P(res) != IS_FALSE)) {
@@ -173,11 +173,11 @@ PHP_METHOD(RdKafka__KafkaErrorException, transactionRequiresAbort)
 {
     zval *res;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("transactionRequiresAbort"), 0 TSRMLS_CC);
+    res = rdkafka_read_property(ce_kafka_error, getThis(), ZEND_STRL("transactionRequiresAbort"), 0);
 
 #if PHP_MAJOR_VERSION >= 7
     if (!res || (Z_TYPE_P(res) != IS_TRUE && Z_TYPE_P(res) != IS_FALSE)) {
@@ -201,15 +201,15 @@ static const zend_function_entry kafka_error_fe[] = { /* {{{ */
     PHP_FE_END
 }; /* }}} */
 
-void kafka_error_minit(TSRMLS_D) /* {{{ */
+void kafka_error_minit() /* {{{ */
 {
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "RdKafka", "KafkaErrorException", kafka_error_fe);
-    ce_kafka_error = rdkafka_register_internal_class_ex(&ce, ce_kafka_exception TSRMLS_CC);
+    ce_kafka_error = rdkafka_register_internal_class_ex(&ce, ce_kafka_exception);
 
-    zend_declare_property_null(ce_kafka_error, ZEND_STRL("error_string"), ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("isFatal"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("isRetriable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
-    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("transactionRequiresAbort"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
+    zend_declare_property_null(ce_kafka_error, ZEND_STRL("error_string"), ZEND_ACC_PRIVATE);
+    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("isFatal"), 0, ZEND_ACC_PRIVATE);
+    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("isRetriable"), 0, ZEND_ACC_PRIVATE);
+    zend_declare_property_bool(ce_kafka_error, ZEND_STRL("transactionRequiresAbort"), 0, ZEND_ACC_PRIVATE);
 } /* }}} */

--- a/kafka_error_exception.h
+++ b/kafka_error_exception.h
@@ -20,6 +20,6 @@
 #include "zeval.h"
 #include "librdkafka/rdkafka.h"
 extern zend_class_entry * ce_kafka_error;
-void kafka_error_minit(TSRMLS_D);
-void create_kafka_error(zval *return_value, const rd_kafka_error_t *error TSRMLS_DC);
+void kafka_error_minit();
+void create_kafka_error(zval *return_value, const rd_kafka_error_t *error);
 #endif

--- a/message.c
+++ b/message.c
@@ -32,7 +32,7 @@
 
 zend_class_entry * ce_kafka_message;
 
-void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSRMLS_DC)
+void kafka_message_new(zval *return_value, const rd_kafka_message_t *message)
 {
     object_init_ex(return_value, ce_kafka_message);
 
@@ -51,21 +51,21 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSR
     uint i;
 #endif /* HAVE_RD_KAFKA_MESSAGE_HEADERS */
 
-    zend_update_property_long(NULL, return_value, ZEND_STRL("err"), message->err TSRMLS_CC);
+    zend_update_property_long(NULL, return_value, ZEND_STRL("err"), message->err);
 
     if (message->rkt) {
-        zend_update_property_string(NULL, return_value, ZEND_STRL("topic_name"), rd_kafka_topic_name(message->rkt) TSRMLS_CC);
+        zend_update_property_string(NULL, return_value, ZEND_STRL("topic_name"), rd_kafka_topic_name(message->rkt));
     }
-    zend_update_property_long(NULL, return_value, ZEND_STRL("partition"), message->partition TSRMLS_CC);
+    zend_update_property_long(NULL, return_value, ZEND_STRL("partition"), message->partition);
     if (message->payload) {
-        zend_update_property_long(NULL, return_value, ZEND_STRL("timestamp"), timestamp TSRMLS_CC);
-        zend_update_property_stringl(NULL, return_value, ZEND_STRL("payload"), message->payload, message->len TSRMLS_CC);
-        zend_update_property_long(NULL, return_value, ZEND_STRL("len"), message->len TSRMLS_CC);
+        zend_update_property_long(NULL, return_value, ZEND_STRL("timestamp"), timestamp);
+        zend_update_property_stringl(NULL, return_value, ZEND_STRL("payload"), message->payload, message->len);
+        zend_update_property_long(NULL, return_value, ZEND_STRL("len"), message->len);
     }
     if (message->key) {
-        zend_update_property_stringl(NULL, return_value, ZEND_STRL("key"), message->key, message->key_len TSRMLS_CC);
+        zend_update_property_stringl(NULL, return_value, ZEND_STRL("key"), message->key, message->key_len);
     }
-    zend_update_property_long(NULL, return_value, ZEND_STRL("offset"), message->offset TSRMLS_CC);
+    zend_update_property_long(NULL, return_value, ZEND_STRL("offset"), message->offset);
 
 #ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
     if (message->err == RD_KAFKA_RESP_ERR_NO_ERROR) {
@@ -79,14 +79,14 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSR
                 }
                 rdkafka_add_assoc_stringl(&headers_array, header_name, (const char*)header_value, header_size);
             }
-            zend_update_property(NULL, return_value, ZEND_STRL("headers"), &headers_array TSRMLS_CC);
+            zend_update_property(NULL, return_value, ZEND_STRL("headers"), &headers_array);
             zval_ptr_dtor(&headers_array);
         }
     }
 #endif
 }
 
-void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size TSRMLS_DC) /* {{{ */
+void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size) /* {{{ */
 {
     rd_kafka_message_t *msg;
     zeval zmsg;
@@ -97,7 +97,7 @@ void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messag
     for (i = 0; i < size; i++) {
         msg = messages[i];
         MAKE_STD_ZEVAL(zmsg);
-        kafka_message_new(P_ZEVAL(zmsg), msg TSRMLS_CC);
+        kafka_message_new(P_ZEVAL(zmsg), msg);
         add_next_index_zval(return_value, P_ZEVAL(zmsg));
     }
 } /* }}} */
@@ -115,11 +115,11 @@ PHP_METHOD(RdKafka__Message, errstr)
     zval *zpayload;
     const char *errstr;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "") == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "") == FAILURE) {
         return;
     }
 
-    zerr = rdkafka_read_property(NULL, getThis(), ZEND_STRL("err"), 0 TSRMLS_CC);
+    zerr = rdkafka_read_property(NULL, getThis(), ZEND_STRL("err"), 0);
 
     if (!zerr || Z_TYPE_P(zerr) != IS_LONG) {
         return;
@@ -131,7 +131,7 @@ PHP_METHOD(RdKafka__Message, errstr)
         RDKAFKA_RETURN_STRING(errstr);
     }
 
-    zpayload = rdkafka_read_property(NULL, getThis(), ZEND_STRL("payload"), 0 TSRMLS_CC);
+    zpayload = rdkafka_read_property(NULL, getThis(), ZEND_STRL("payload"), 0);
 
     if (zpayload && Z_TYPE_P(zpayload) == IS_STRING) {
         RETURN_ZVAL(zpayload, 1, 0);
@@ -144,21 +144,21 @@ static const zend_function_entry kafka_message_fe[] = {
     PHP_FE_END
 };
 
-void kafka_message_minit(TSRMLS_D) { /* {{{ */
+void kafka_message_minit() { /* {{{ */
     zend_class_entry ce;
 
     INIT_NS_CLASS_ENTRY(ce, "RdKafka", "Message", kafka_message_fe);
-    ce_kafka_message = zend_register_internal_class(&ce TSRMLS_CC);
+    ce_kafka_message = zend_register_internal_class(&ce);
 
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("err"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("topic_name"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("timestamp"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("partition"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("payload"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("len"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("key"), ZEND_ACC_PUBLIC TSRMLS_CC);
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("offset"), ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("err"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("topic_name"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("timestamp"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("partition"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("payload"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("len"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("key"), ZEND_ACC_PUBLIC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("offset"), ZEND_ACC_PUBLIC);
 #ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
-    zend_declare_property_null(ce_kafka_message, ZEND_STRL("headers"), ZEND_ACC_PUBLIC TSRMLS_CC);
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("headers"), ZEND_ACC_PUBLIC);
 #endif
 } /* }}} */

--- a/message.h
+++ b/message.h
@@ -16,8 +16,8 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_message_minit(TSRMLS_D);
-void kafka_message_new(zval *return_value, const rd_kafka_message_t *message TSRMLS_DC);
-void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size TSRMLS_DC);
+void kafka_message_minit();
+void kafka_message_new(zval *return_value, const rd_kafka_message_t *message);
+void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size);
 
 extern zend_class_entry * ce_kafka_message;

--- a/metadata.c
+++ b/metadata.c
@@ -41,22 +41,22 @@ typedef struct _object_intern {
 #endif
 } object_intern;
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC);
+static HashTable *get_debug_info(zval *object, int *is_temp);
 
 static zend_class_entry * ce;
 static zend_object_handlers handlers;
 
-static void brokers_collection(zval *return_value, zval *parent, object_intern *intern TSRMLS_DC) { /* {{{ */
-    kafka_metadata_collection_init(return_value, parent, intern->metadata->brokers, intern->metadata->broker_cnt, sizeof(*intern->metadata->brokers), kafka_metadata_broker_ctor TSRMLS_CC);
+static void brokers_collection(zval *return_value, zval *parent, object_intern *intern) { /* {{{ */
+    kafka_metadata_collection_init(return_value, parent, intern->metadata->brokers, intern->metadata->broker_cnt, sizeof(*intern->metadata->brokers), kafka_metadata_broker_ctor);
 }
 /* }}} */
 
-static void topics_collection(zval *return_value, zval *parent, object_intern *intern TSRMLS_DC) { /* {{{ */
-    kafka_metadata_collection_init(return_value, parent, intern->metadata->topics, intern->metadata->topic_cnt, sizeof(*intern->metadata->topics), kafka_metadata_topic_ctor TSRMLS_CC);
+static void topics_collection(zval *return_value, zval *parent, object_intern *intern) { /* {{{ */
+    kafka_metadata_collection_init(return_value, parent, intern->metadata->topics, intern->metadata->topic_cnt, sizeof(*intern->metadata->topics), kafka_metadata_topic_ctor);
 }
 /* }}} */
 
-static void kafka_metadata_free(zend_object *object TSRMLS_DC) /* {{{ */
+static void kafka_metadata_free(zend_object *object) /* {{{ */
 {
     object_intern *intern = get_custom_object(object_intern, object);
 
@@ -64,19 +64,19 @@ static void kafka_metadata_free(zend_object *object TSRMLS_DC) /* {{{ */
         rd_kafka_metadata_destroy(intern->metadata);
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value kafka_metadata_new(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value kafka_metadata_new(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     object_intern *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
     STORE_OBJECT(retval, intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, kafka_metadata_free, NULL);
@@ -86,19 +86,19 @@ static zend_object_value kafka_metadata_new(zend_class_entry *class_type TSRMLS_
 }
 /* }}} */
 
-static object_intern * get_object(zval *zmetadata TSRMLS_DC)
+static object_intern * get_object(zval *zmetadata)
 {
     object_intern *ometadata = get_custom_object_zval(object_intern, zmetadata);
 
     if (!ometadata->metadata) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Metadata::__construct() has not been called");
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Metadata::__construct() has not been called");
         return NULL;
     }
 
     return ometadata;
 }
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
+static HashTable *get_debug_info(zval *object, int *is_temp) /* {{{ */
 {
     zval ary;
     object_intern *intern;
@@ -109,17 +109,17 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 
     array_init(&ary);
 
-    intern = get_object(object TSRMLS_CC);
+    intern = get_object(object);
     if (!intern) {
         return Z_ARRVAL(ary);
     }
 
     MAKE_STD_ZEVAL(brokers);
-    brokers_collection(P_ZEVAL(brokers), object, intern TSRMLS_CC);
+    brokers_collection(P_ZEVAL(brokers), object, intern);
     add_assoc_zval(&ary, "brokers", P_ZEVAL(brokers));
 
     MAKE_STD_ZEVAL(topics);
-    topics_collection(P_ZEVAL(topics), object, intern TSRMLS_CC);
+    topics_collection(P_ZEVAL(topics), object, intern);
     add_assoc_zval(&ary, "topics", P_ZEVAL(topics));
 
     add_assoc_long(&ary, "orig_broker_id", intern->metadata->orig_broker_id);
@@ -143,7 +143,7 @@ PHP_METHOD(RdKafka__Metadata, getOrigBrokerId)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -166,7 +166,7 @@ PHP_METHOD(RdKafka__Metadata, getOrigBrokerName)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -189,12 +189,12 @@ PHP_METHOD(RdKafka__Metadata, getBrokers)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
 
-    brokers_collection(return_value, getThis(), intern TSRMLS_CC);
+    brokers_collection(return_value, getThis(), intern);
 }
 /* }}} */
 
@@ -212,12 +212,12 @@ PHP_METHOD(RdKafka__Metadata, getTopics)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
 
-    topics_collection(return_value, getThis(), intern TSRMLS_CC);
+    topics_collection(return_value, getThis(), intern);
 }
 /* }}} */
 
@@ -229,12 +229,12 @@ static const zend_function_entry kafka_metadata_fe[] = {
     PHP_FE_END
 };
 
-void kafka_metadata_minit(TSRMLS_D)
+void kafka_metadata_minit()
 {
     zend_class_entry tmpce;
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka", "Metadata", kafka_metadata_fe);
-    ce = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce = zend_register_internal_class(&tmpce);
     ce->create_object = kafka_metadata_new;
 
     handlers = kafka_default_object_handlers;
@@ -242,13 +242,13 @@ void kafka_metadata_minit(TSRMLS_D)
     set_object_handler_free_obj(&handlers, kafka_metadata_free);
     set_object_handler_offset(&handlers, XtOffsetOf(object_intern, std));
 
-    kafka_metadata_topic_minit(TSRMLS_C);
-    kafka_metadata_broker_minit(TSRMLS_C);
-    kafka_metadata_partition_minit(TSRMLS_C);
-    kafka_metadata_collection_minit(TSRMLS_C);
+    kafka_metadata_topic_minit();
+    kafka_metadata_broker_minit();
+    kafka_metadata_partition_minit();
+    kafka_metadata_collection_minit();
 }
 
-void kafka_metadata_init(zval *return_value, const rd_kafka_metadata_t *metadata TSRMLS_DC)
+void kafka_metadata_init(zval *return_value, const rd_kafka_metadata_t *metadata)
 {
     object_intern *intern;
 

--- a/metadata.h
+++ b/metadata.h
@@ -16,5 +16,5 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_metadata_minit(TSRMLS_D);
-void kafka_metadata_init(zval *return_value, const rd_kafka_metadata_t *metadata TSRMLS_DC);
+void kafka_metadata_minit();
+void kafka_metadata_init(zval *return_value, const rd_kafka_metadata_t *metadata);

--- a/metadata_broker.c
+++ b/metadata_broker.c
@@ -40,12 +40,12 @@ typedef struct _object_intern {
 #endif
 } object_intern;
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC);
+static HashTable *get_debug_info(zval *object, int *is_temp);
 
 static zend_class_entry * ce;
 static zend_object_handlers handlers;
 
-static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
+static void free_object(zend_object *object) /* {{{ */
 {
     object_intern *intern = get_custom_object(object_intern, object);
 
@@ -53,19 +53,19 @@ static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
         zval_dtor(&intern->zmetadata);
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value create_object(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     object_intern *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
 
@@ -76,19 +76,19 @@ static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /
 }
 /* }}} */
 
-static object_intern * get_object(zval *zmt TSRMLS_DC)
+static object_intern * get_object(zval *zmt)
 {
     object_intern *omt = get_custom_object_zval(object_intern, zmt);
 
     if (!omt->metadata_broker) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Metadata\\Broker::__construct() has not been called");
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Metadata\\Broker::__construct() has not been called");
         return NULL;
     }
 
     return omt;
 }
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
+static HashTable *get_debug_info(zval *object, int *is_temp) /* {{{ */
 {
     zval ary;
     object_intern *intern;
@@ -97,7 +97,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 
     array_init(&ary);
 
-    intern = get_object(object TSRMLS_CC);
+    intern = get_object(object);
     if (!intern) {
         return Z_ARRVAL(ary);
     }
@@ -124,7 +124,7 @@ PHP_METHOD(RdKafka__Metadata__Broker, getId)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -147,7 +147,7 @@ PHP_METHOD(RdKafka__Metadata__Broker, getHost)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -170,7 +170,7 @@ PHP_METHOD(RdKafka__Metadata__Broker, getPort)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -186,12 +186,12 @@ static const zend_function_entry fe[] = {
     PHP_FE_END
 };
 
-void kafka_metadata_broker_minit(TSRMLS_D)
+void kafka_metadata_broker_minit()
 {
     zend_class_entry tmpce;
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka", "Metadata\\Broker", fe);
-    ce = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce = zend_register_internal_class(&tmpce);
     ce->create_object = create_object;
 
     handlers = kafka_default_object_handlers;
@@ -200,7 +200,7 @@ void kafka_metadata_broker_minit(TSRMLS_D)
     set_object_handler_offset(&handlers, XtOffsetOf(object_intern, std));
 }
 
-void kafka_metadata_broker_ctor(zval *return_value, zval *zmetadata, const void *data TSRMLS_DC)
+void kafka_metadata_broker_ctor(zval *return_value, zval *zmetadata, const void *data)
 {
     rd_kafka_metadata_broker_t *metadata_broker = (rd_kafka_metadata_broker_t*)data;
     object_intern *intern;

--- a/metadata_broker.h
+++ b/metadata_broker.h
@@ -16,5 +16,5 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_metadata_broker_minit(TSRMLS_D);
-void kafka_metadata_broker_ctor(zval *return_value, zval *zmetadata, const void *metadata_broker TSRMLS_DC);
+void kafka_metadata_broker_minit();
+void kafka_metadata_broker_ctor(zval *return_value, zval *zmetadata, const void *metadata_broker);

--- a/metadata_collection.h
+++ b/metadata_collection.h
@@ -16,7 +16,7 @@
   +----------------------------------------------------------------------+
 */
 
-typedef void (*kafka_metadata_collection_ctor_t)(zval *renurn_value, zval *zmetadata, const void *object TSRMLS_DC);
+typedef void (*kafka_metadata_collection_ctor_t)(zval *renurn_value, zval *zmetadata, const void *object);
 
-void kafka_metadata_collection_minit(TSRMLS_D);
-void kafka_metadata_collection_init(zval *return_value, zval *zmetadata, const void * items, size_t item_cnt, size_t item_size, kafka_metadata_collection_ctor_t ctor TSRMLS_DC);
+void kafka_metadata_collection_minit();
+void kafka_metadata_collection_init(zval *return_value, zval *zmetadata, const void * items, size_t item_cnt, size_t item_size, kafka_metadata_collection_ctor_t ctor);

--- a/metadata_partition.c
+++ b/metadata_partition.c
@@ -40,12 +40,12 @@ typedef struct _object_intern {
 #endif
 } object_intern;
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC);
+static HashTable *get_debug_info(zval *object, int *is_temp);
 
 static zend_class_entry * ce;
 static zend_object_handlers handlers;
 
-static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
+static void free_object(zend_object *object) /* {{{ */
 {
     object_intern *intern = get_custom_object(object_intern, object);
 
@@ -53,19 +53,19 @@ static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
         zval_dtor(&intern->zmetadata);
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value create_object(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     object_intern *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
     STORE_OBJECT(retval, intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, free_object, NULL);
@@ -75,19 +75,19 @@ static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /
 }
 /* }}} */
 
-static object_intern * get_object(zval *zmt TSRMLS_DC)
+static object_intern * get_object(zval *zmt)
 {
     object_intern *omt = get_custom_object_zval(object_intern, zmt);
 
     if (!omt->metadata_partition) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Metadata\\Partition::__construct() has not been called");
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Metadata\\Partition::__construct() has not been called");
         return NULL;
     }
 
     return omt;
 }
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
+static HashTable *get_debug_info(zval *object, int *is_temp) /* {{{ */
 {
     zval ary;
     object_intern *intern;
@@ -96,7 +96,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 
     array_init(&ary);
 
-    intern = get_object(object TSRMLS_CC);
+    intern = get_object(object);
     if (!intern) {
         return Z_ARRVAL(ary);
     }
@@ -125,7 +125,7 @@ PHP_METHOD(RdKafka__Metadata__Partition, getId)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -148,7 +148,7 @@ PHP_METHOD(RdKafka__Metadata__Partition, getErr)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -171,7 +171,7 @@ PHP_METHOD(RdKafka__Metadata__Partition, getLeader)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -180,7 +180,7 @@ PHP_METHOD(RdKafka__Metadata__Partition, getLeader)
 }
 /* }}} */
 
-void int32_ctor(zval *return_value, zval *zmetadata, const void *data TSRMLS_DC) {
+void int32_ctor(zval *return_value, zval *zmetadata, const void *data) {
     ZVAL_LONG(return_value, *(int32_t*)data);
 }
 
@@ -198,12 +198,12 @@ PHP_METHOD(RdKafka__Metadata__Partition, getReplicas)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
 
-    kafka_metadata_collection_init(return_value, getThis(), intern->metadata_partition->replicas, intern->metadata_partition->replica_cnt, sizeof(*intern->metadata_partition->replicas), int32_ctor TSRMLS_CC);
+    kafka_metadata_collection_init(return_value, getThis(), intern->metadata_partition->replicas, intern->metadata_partition->replica_cnt, sizeof(*intern->metadata_partition->replicas), int32_ctor);
 }
 /* }}} */
 
@@ -221,12 +221,12 @@ PHP_METHOD(RdKafka__Metadata__Partition, getIsrs)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
 
-    kafka_metadata_collection_init(return_value, getThis(), intern->metadata_partition->isrs, intern->metadata_partition->isr_cnt, sizeof(*intern->metadata_partition->isrs), int32_ctor TSRMLS_CC);
+    kafka_metadata_collection_init(return_value, getThis(), intern->metadata_partition->isrs, intern->metadata_partition->isr_cnt, sizeof(*intern->metadata_partition->isrs), int32_ctor);
 }
 /* }}} */
 
@@ -239,12 +239,12 @@ static const zend_function_entry fe[] = {
     PHP_FE_END
 };
 
-void kafka_metadata_partition_minit(TSRMLS_D)
+void kafka_metadata_partition_minit()
 {
     zend_class_entry tmpce;
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka", "Metadata\\Partition", fe);
-    ce = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce = zend_register_internal_class(&tmpce);
     ce->create_object = create_object;
 
     handlers = kafka_default_object_handlers;
@@ -253,7 +253,7 @@ void kafka_metadata_partition_minit(TSRMLS_D)
     set_object_handler_offset(&handlers, XtOffsetOf(object_intern, std));
 }
 
-void kafka_metadata_partition_ctor(zval *return_value, zval *zmetadata, const void *data TSRMLS_DC)
+void kafka_metadata_partition_ctor(zval *return_value, zval *zmetadata, const void *data)
 {
     rd_kafka_metadata_partition_t *metadata_partition = (rd_kafka_metadata_partition_t*)data;
     object_intern *intern;

--- a/metadata_partition.h
+++ b/metadata_partition.h
@@ -16,5 +16,5 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_metadata_partition_minit(TSRMLS_D);
-void kafka_metadata_partition_ctor(zval *return_value, zval *zmetadata, const void *metadata_partition TSRMLS_DC);
+void kafka_metadata_partition_minit();
+void kafka_metadata_partition_ctor(zval *return_value, zval *zmetadata, const void *metadata_partition);

--- a/metadata_topic.c
+++ b/metadata_topic.c
@@ -42,17 +42,17 @@ typedef struct _object_intern {
 #endif
 } object_intern;
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC);
+static HashTable *get_debug_info(zval *object, int *is_temp);
 
 static zend_class_entry * ce;
 static zend_object_handlers handlers;
 
-static void partitions_collection(zval *return_value, zval *parent, object_intern *intern TSRMLS_DC) { /* {{{ */
-    kafka_metadata_collection_init(return_value, parent, intern->metadata_topic->partitions, intern->metadata_topic->partition_cnt, sizeof(*intern->metadata_topic->partitions), kafka_metadata_partition_ctor TSRMLS_CC);
+static void partitions_collection(zval *return_value, zval *parent, object_intern *intern) { /* {{{ */
+    kafka_metadata_collection_init(return_value, parent, intern->metadata_topic->partitions, intern->metadata_topic->partition_cnt, sizeof(*intern->metadata_topic->partitions), kafka_metadata_partition_ctor);
 }
 /* }}} */
 
-static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
+static void free_object(zend_object *object) /* {{{ */
 {
     object_intern *intern = get_custom_object(object_intern, object);
 
@@ -60,19 +60,19 @@ static void free_object(zend_object *object TSRMLS_DC) /* {{{ */
         zval_dtor(&intern->zmetadata);
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value create_object(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     object_intern *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
     STORE_OBJECT(retval, intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, free_object, NULL);
@@ -82,19 +82,19 @@ static zend_object_value create_object(zend_class_entry *class_type TSRMLS_DC) /
 }
 /* }}} */
 
-static object_intern * get_object(zval *zmt TSRMLS_DC)
+static object_intern * get_object(zval *zmt)
 {
     object_intern *omt = get_custom_object_zval(object_intern, zmt);
 
     if (!omt->metadata_topic) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Metadata\\Topic::__construct() has not been called");
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Metadata\\Topic::__construct() has not been called");
         return NULL;
     }
 
     return omt;
 }
 
-static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
+static HashTable *get_debug_info(zval *object, int *is_temp) /* {{{ */
 {
     zval ary;
     object_intern *intern;
@@ -104,7 +104,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
 
     array_init(&ary);
 
-    intern = get_object(object TSRMLS_CC);
+    intern = get_object(object);
     if (!intern) {
         return Z_ARRVAL(ary);
     }
@@ -112,7 +112,7 @@ static HashTable *get_debug_info(zval *object, int *is_temp TSRMLS_DC) /* {{{ */
     rdkafka_add_assoc_string(&ary, "topic", intern->metadata_topic->topic);
 
     MAKE_STD_ZEVAL(partitions);
-    partitions_collection(P_ZEVAL(partitions), object, intern TSRMLS_CC);
+    partitions_collection(P_ZEVAL(partitions), object, intern);
     add_assoc_zval(&ary, "partitions", P_ZEVAL(partitions));
 
     add_assoc_long(&ary, "err", intern->metadata_topic->err);
@@ -135,7 +135,7 @@ PHP_METHOD(RdKafka__Metadata__Topic, getTopic)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -158,7 +158,7 @@ PHP_METHOD(RdKafka__Metadata__Topic, getErr)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
@@ -182,12 +182,12 @@ PHP_METHOD(RdKafka__Metadata__Topic, getPartitions)
         return;
     }
 
-    intern = get_object(getThis() TSRMLS_CC);
+    intern = get_object(getThis());
     if (!intern) {
         return;
     }
 
-    partitions_collection(return_value, getThis(), intern TSRMLS_CC);
+    partitions_collection(return_value, getThis(), intern);
 }
 /* }}} */
 
@@ -198,12 +198,12 @@ static const zend_function_entry fe[] = {
     PHP_FE_END
 };
 
-void kafka_metadata_topic_minit(TSRMLS_D)
+void kafka_metadata_topic_minit()
 {
     zend_class_entry tmpce;
 
     INIT_NS_CLASS_ENTRY(tmpce, "RdKafka\\Metadata", "Topic", fe);
-    ce = zend_register_internal_class(&tmpce TSRMLS_CC);
+    ce = zend_register_internal_class(&tmpce);
     ce->create_object = create_object;
 
     handlers = kafka_default_object_handlers;
@@ -212,7 +212,7 @@ void kafka_metadata_topic_minit(TSRMLS_D)
     set_object_handler_offset(&handlers, XtOffsetOf(object_intern, std));
 }
 
-void kafka_metadata_topic_ctor(zval *return_value, zval *zmetadata, const void *data TSRMLS_DC)
+void kafka_metadata_topic_ctor(zval *return_value, zval *zmetadata, const void *data)
 {
     rd_kafka_metadata_topic_t *metadata_topic = (rd_kafka_metadata_topic_t*)data;
     object_intern *intern;

--- a/metadata_topic.h
+++ b/metadata_topic.h
@@ -16,5 +16,5 @@
   +----------------------------------------------------------------------+
 */
 
-void kafka_metadata_topic_minit(TSRMLS_D);
-void kafka_metadata_topic_ctor(zval *return_value, zval *zmetadata, const void *metadata_topic TSRMLS_DC);
+void kafka_metadata_topic_minit();
+void kafka_metadata_topic_ctor(zval *return_value, zval *zmetadata, const void *metadata_topic);

--- a/php_rdkafka_priv.h
+++ b/php_rdkafka_priv.h
@@ -51,7 +51,7 @@ static inline zend_object * is_zend_object(zend_object * object) {
 
 #define free_custom_object(object) /* no-op */
 
-static inline zend_class_entry *rdkafka_register_internal_class_ex(zend_class_entry *class_entry, zend_class_entry *parent_ce TSRMLS_DC)
+static inline zend_class_entry *rdkafka_register_internal_class_ex(zend_class_entry *class_entry, zend_class_entry *parent_ce)
 {
     return zend_register_internal_class_ex(class_entry, parent_ce);
 }
@@ -65,7 +65,7 @@ static inline void set_object_handler_offset(zend_object_handlers * handlers, si
     handlers->offset = offset;
 }
 
-static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zval *retval, uint32_t param_count, zval params[] TSRMLS_DC)
+static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zval *retval, uint32_t param_count, zval params[])
 {
     int local_retval;
     zval local_retval_zv;
@@ -81,17 +81,17 @@ static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_c
     fci->params = params;
     fci->param_count = param_count;
 
-    zend_call_function(fci, fci_cache TSRMLS_CC);
+    zend_call_function(fci, fci_cache);
 
     if (local_retval) {
         zval_ptr_dtor(retval);
     }
 }
 
-static inline zval *rdkafka_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent TSRMLS_DC)
+static inline zval *rdkafka_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent)
 {
     zval rv;
-    return zend_read_property(scope, object, name, name_length, silent, &rv TSRMLS_CC);
+    return zend_read_property(scope, object, name, name_length, silent, &rv);
 }
 
 static inline zval *rdkafka_hash_get_current_data_ex(HashTable *ht, HashPosition *pos)
@@ -125,8 +125,8 @@ typedef long zend_long;
 typedef int arglen_t;
 
 #define STORE_OBJECT(retval, intern, dtor, free, clone) do { \
-    void (*___free_object_storage)(zend_object *object TSRMLS_DC) = free; \
-    retval.handle = zend_objects_store_put(&intern->std, dtor, (zend_objects_free_object_storage_t)___free_object_storage, clone TSRMLS_CC); \
+    void (*___free_object_storage)(zend_object *object) = free; \
+    retval.handle = zend_objects_store_put(&intern->std, dtor, (zend_objects_free_object_storage_t)___free_object_storage, clone); \
 } while (0)
 
 #define SET_OBJECT_HANDLERS(retval, _handlers) do { \
@@ -136,7 +136,7 @@ typedef int arglen_t;
 #define alloc_object(intern, ce) ecalloc(1, sizeof(*intern))
 
 #define get_custom_object_zval(type, zobject) \
-    ((type*)zend_object_store_get_object(zobject TSRMLS_CC))
+    ((type*)zend_object_store_get_object(zobject))
 
 #define get_custom_object(type, object) \
     ((type*)object)
@@ -167,9 +167,9 @@ static inline void *zend_hash_index_add_ptr(HashTable *ht, zend_ulong h, void *p
     return pDest;
 }
 
-static inline zend_class_entry *rdkafka_register_internal_class_ex(zend_class_entry *class_entry, zend_class_entry *parent_ce TSRMLS_DC)
+static inline zend_class_entry *rdkafka_register_internal_class_ex(zend_class_entry *class_entry, zend_class_entry *parent_ce)
 {
-    return zend_register_internal_class_ex(class_entry, parent_ce, NULL TSRMLS_CC);
+    return zend_register_internal_class_ex(class_entry, parent_ce, NULL);
 }
 
 typedef void (*zend_object_free_obj_t)(zend_object *object);
@@ -183,7 +183,7 @@ static inline void set_object_handler_offset(zend_object_handlers * handlers, si
     /* no-op */
 }
 
-static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zval **retval, uint32_t param_count, zval *params[] TSRMLS_DC)
+static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_cache *fci_cache, zval **retval, uint32_t param_count, zval *params[])
 {
     uint32_t i;
     int local_retval;
@@ -206,7 +206,7 @@ static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_c
     fci->params = params_array;
     fci->param_count = param_count;
 
-    zend_call_function(fci, fci_cache TSRMLS_CC);
+    zend_call_function(fci, fci_cache);
 
     if (local_retval && *retval) {
         zval_ptr_dtor(retval);
@@ -215,9 +215,9 @@ static inline void rdkafka_call_function(zend_fcall_info *fci, zend_fcall_info_c
     efree(params_array);
 }
 
-static inline zval *rdkafka_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent TSRMLS_DC)
+static inline zval *rdkafka_read_property(zend_class_entry *scope, zval *object, const char *name, size_t name_length, zend_bool silent)
 {
-    return zend_read_property(scope, object, name, name_length, silent TSRMLS_CC);
+    return zend_read_property(scope, object, name, name_length, silent);
 }
 
 static inline zval **rdkafka_hash_get_current_data_ex(HashTable *ht, HashPosition *pos)
@@ -252,7 +252,7 @@ static inline char **rdkafka_hash_get_current_key_ex(HashTable *ht, HashPosition
 #define RDKAFKA_ZVAL_STRING(zv, str) ZVAL_STRING(zv, str, 1)
 #endif
 
-kafka_object * get_kafka_object(zval *zrk TSRMLS_DC);
+kafka_object * get_kafka_object(zval *zrk);
 void add_consuming_toppar(kafka_object * intern, rd_kafka_topic_t * rkt, int32_t partition);
 void del_consuming_toppar(kafka_object * intern, rd_kafka_topic_t * rkt, int32_t partition);
 int is_consuming_toppar(kafka_object * intern, rd_kafka_topic_t * rkt, int32_t partition);

--- a/queue.c
+++ b/queue.c
@@ -35,30 +35,30 @@ zend_class_entry * ce_kafka_queue;
 
 static zend_object_handlers handlers;
 
-static void kafka_queue_free(zend_object *object TSRMLS_DC) /* {{{ */
+static void kafka_queue_free(zend_object *object) /* {{{ */
 {
     kafka_queue_object *intern = get_custom_object(kafka_queue_object, object);
 
     if (intern->rkqu) {
-        kafka_object *kafka_intern = get_kafka_object(P_ZEVAL(intern->zrk) TSRMLS_CC);
+        kafka_object *kafka_intern = get_kafka_object(P_ZEVAL(intern->zrk));
         if (kafka_intern) {
             zend_hash_index_del(&kafka_intern->queues, (zend_ulong)intern);
         }
     }
 
-    zend_object_std_dtor(&intern->std TSRMLS_CC);
+    zend_object_std_dtor(&intern->std);
 
     free_custom_object(intern);
 }
 /* }}} */
 
-static zend_object_value kafka_queue_new(zend_class_entry *class_type TSRMLS_DC) /* {{{ */
+static zend_object_value kafka_queue_new(zend_class_entry *class_type) /* {{{ */
 {
     zend_object_value retval;
     kafka_queue_object *intern;
 
     intern = alloc_object(intern, class_type);
-    zend_object_std_init(&intern->std, class_type TSRMLS_CC);
+    zend_object_std_init(&intern->std, class_type);
     object_properties_init(&intern->std, class_type);
 
     STORE_OBJECT(retval, intern, (zend_objects_store_dtor_t) zend_objects_destroy_object, kafka_queue_free, NULL);
@@ -68,12 +68,12 @@ static zend_object_value kafka_queue_new(zend_class_entry *class_type TSRMLS_DC)
 }
 /* }}} */
 
-kafka_queue_object * get_kafka_queue_object(zval *zrkqu TSRMLS_DC)
+kafka_queue_object * get_kafka_queue_object(zval *zrkqu)
 {
     kafka_queue_object *orkqu = get_custom_object_zval(kafka_queue_object, zrkqu);
 
     if (!orkqu->rkqu) {
-        zend_throw_exception_ex(NULL, 0 TSRMLS_CC, "RdKafka\\Queue::__construct() has not been called" TSRMLS_CC);
+        zend_throw_exception_ex(NULL, 0, "RdKafka\\Queue::__construct() has not been called");
         return NULL;
     }
 
@@ -94,11 +94,11 @@ PHP_METHOD(RdKafka__Queue, consume)
     rd_kafka_message_t *message;
     rd_kafka_resp_err_t err;
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &timeout_ms) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &timeout_ms) == FAILURE) {
         return;
     }
 
-    intern = get_kafka_queue_object(getThis() TSRMLS_CC);
+    intern = get_kafka_queue_object(getThis());
     if (!intern) {
         return;
     }
@@ -110,11 +110,11 @@ PHP_METHOD(RdKafka__Queue, consume)
         if (err == RD_KAFKA_RESP_ERR__TIMED_OUT) {
             return;
         }
-        zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err TSRMLS_CC);
+        zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err);
         return;
     }
 
-    kafka_message_new(return_value, message TSRMLS_CC);
+    kafka_message_new(return_value, message);
 
     rd_kafka_message_destroy(message);
 }
@@ -129,7 +129,7 @@ static const zend_function_entry kafka_queue_fe[] = {
     PHP_FE_END
 };
 
-void kafka_queue_minit(TSRMLS_D) { /* {{{ */
+void kafka_queue_minit() { /* {{{ */
 
     zend_class_entry ce;
 
@@ -138,6 +138,6 @@ void kafka_queue_minit(TSRMLS_D) { /* {{{ */
     set_object_handler_offset(&handlers, XtOffsetOf(kafka_queue_object, std));
 
     INIT_NS_CLASS_ENTRY(ce, "RdKafka", "Queue", kafka_queue_fe);
-    ce_kafka_queue = zend_register_internal_class(&ce TSRMLS_CC);
+    ce_kafka_queue = zend_register_internal_class(&ce);
     ce_kafka_queue->create_object = kafka_queue_new;
 } /* }}} */

--- a/queue.h
+++ b/queue.h
@@ -27,7 +27,7 @@ typedef struct _kafka_queue_object {
 #endif
 } kafka_queue_object;
 
-void kafka_queue_minit(TSRMLS_D);
-kafka_queue_object * get_kafka_queue_object(zval *zrkqu TSRMLS_DC);
+void kafka_queue_minit();
+kafka_queue_object * get_kafka_queue_object(zval *zrkqu);
 
 extern zend_class_entry * ce_kafka_queue;

--- a/tests/conf_setDefaultTopicConf8.phpt
+++ b/tests/conf_setDefaultTopicConf8.phpt
@@ -1,0 +1,38 @@
+--TEST--
+RdKafka\Conf::setDefaultTopicConf()
+--SKIPIF--
+<?php
+if (!method_exists('RdKafka\Conf', 'setDefaultTopicConf') || 8 > PHP_MAJOR_VERSION) {
+    echo "skip";
+}
+?>
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+
+echo "Setting valid topic conf\n";
+$conf->setDefaultTopicConf(new RdKafka\TopicConf());
+
+echo "Setting invalid topic conf\n";
+try {
+    $conf->setDefaultTopicConf($conf);
+} catch(TypeError $error) {
+    echo $error->getMessage() . PHP_EOL;
+    echo $error->getFile() . PHP_EOL;
+    echo $error->getLine() . PHP_EOL;
+    echo $error->getCode();
+}
+
+--EXPECTF--
+Setting valid topic conf
+
+Deprecated: Method RdKafka\Conf::setDefaultTopicConf() is deprecated in %s%econf_setDefaultTopicConf8.php on line 6
+Setting invalid topic conf
+
+Deprecated: Method RdKafka\Conf::setDefaultTopicConf() is deprecated in %s%econf_setDefaultTopicConf8.php on line 10
+RdKafka\Conf::setDefaultTopicConf(): Argument #1 ($topic_conf) must be of type RdKafka\TopicConf, RdKafka\Conf given
+%s%econf_setDefaultTopicConf8.php
+10
+0
+

--- a/topic.h
+++ b/topic.h
@@ -29,8 +29,8 @@ typedef struct _kafka_topic_object {
 #endif
 } kafka_topic_object;
 
-void kafka_topic_minit(TSRMLS_D);
-kafka_topic_object * get_kafka_topic_object(zval *zrkt TSRMLS_DC);
+void kafka_topic_minit();
+kafka_topic_object * get_kafka_topic_object(zval *zrkt);
 
 extern zend_class_entry * ce_kafka_consumer_topic;
 extern zend_class_entry * ce_kafka_kafka_consumer_topic;

--- a/topic_partition.h
+++ b/topic_partition.h
@@ -28,12 +28,12 @@ typedef struct _kafka_topic_partition_intern {
 #endif
 } kafka_topic_partition_intern;
 
-void kafka_metadata_topic_partition_minit(TSRMLS_D);
+void kafka_metadata_topic_partition_minit();
 
-kafka_topic_partition_intern * get_topic_partition_object(zval *z TSRMLS_DC);
-void kafka_topic_partition_init(zval *z, char *topic, int32_t partition, int64_t offset TSRMLS_DC);
+kafka_topic_partition_intern * get_topic_partition_object(zval *z);
+void kafka_topic_partition_init(zval *z, char *topic, int32_t partition, int64_t offset);
 
-void kafka_topic_partition_list_to_array(zval *return_value, rd_kafka_topic_partition_list_t *list TSRMLS_DC);
-rd_kafka_topic_partition_list_t * array_arg_to_kafka_topic_partition_list(int argnum, HashTable *ary TSRMLS_DC);
+void kafka_topic_partition_list_to_array(zval *return_value, rd_kafka_topic_partition_list_t *list);
+rd_kafka_topic_partition_list_t * array_arg_to_kafka_topic_partition_list(int argnum, HashTable *ary);
 
 extern zend_class_entry * ce_kafka_topic_partition;


### PR DESCRIPTION
Drop TSRMLS macro usage, as a first step towards PHP 8 support.

(Author @nick-zh, this is a subset of https://github.com/arnaud-lb/php-rdkafka/pull/383)