### PR TITLE
Fix pecl build (windows)

### DIFF
--- a/kafka_error_exception.c
+++ b/kafka_error_exception.c
@@ -20,6 +20,7 @@
 #include "config.h"
 #endif
 
+#ifdef HAS_RD_KAFKA_TRANSACTIONS
 #include "php.h"
 #include "php_rdkafka.h"
 #include "php_rdkafka_priv.h"
@@ -213,3 +214,5 @@ void kafka_error_minit(TSRMLS_D) /* {{{ */
     zend_declare_property_bool(ce_kafka_error, ZEND_STRL("isRetriable"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
     zend_declare_property_bool(ce_kafka_error, ZEND_STRL("transactionRequiresAbort"), 0, ZEND_ACC_PRIVATE TSRMLS_CC);
 } /* }}} */
+#endif
+


### PR DESCRIPTION
in `config.m4`  we exclude `kafka_error_exception.c` for older `librdkafka` versions, not so in the `config.w32`
I added a block around the c class as well to be sure that we don't get errors in combination with old lib versions