### PR TITLE
uint is not universally available

### DIFF
--- a/message.c
+++ b/message.c
@@ -48,7 +48,7 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message)
     const void *header_value = NULL;
     size_t header_size = 0;
     zval headers_array;
-    uint i;
+    unsigned int i;
 #endif /* HAVE_RD_KAFKA_MESSAGE_HEADERS */
 
     zend_update_property_long(NULL, Z_RDKAFKA_PROP_OBJ(return_value), ZEND_STRL("err"), message->err);


### PR DESCRIPTION
On Windows and macOS, `uint` is not (necessarily) available, so we use
the explicit `unsigned int` instead.

---

To clarify: PHP had a compatibility definition of `uint` prior to 7.4.0, but that has been removed.

Furthermore, this is a straight forward replacement. It might be more correct to use `size_t` instead, since `rd_kafka_header_cnt()` returns `size_t` and `rd_kafka_header_get_all()` expects `size_t` at least with librdkafka 1.5.3.