### PR TITLE
Add opaque on produce(), producev()

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -64,6 +64,8 @@ void kafka_conf_minit(INIT_FUNC_ARGS);
 void kafka_conf_callbacks_dtor(kafka_conf_callbacks *cbs);
 void kafka_conf_callbacks_copy(kafka_conf_callbacks *to, kafka_conf_callbacks *from);
 
+void kafka_conf_dr_msg_cb(rd_kafka_t *rk, const rd_kafka_message_t *msg, void *opaque);
+
 extern zend_class_entry * ce_kafka_conf;
 extern zend_class_entry * ce_kafka_topic_conf;
 

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -392,7 +392,7 @@ PHP_METHOD(RdKafka__KafkaConsumer, consume)
         rkmessage = &rkmessage_tmp;
     }
 
-    kafka_message_new(return_value, rkmessage);
+    kafka_message_new(return_value, rkmessage, NULL);
 
     if (rkmessage != &rkmessage_tmp) {
         rd_kafka_message_destroy(rkmessage);

--- a/message.c
+++ b/message.c
@@ -32,7 +32,7 @@
 
 zend_class_entry * ce_kafka_message;
 
-void kafka_message_new(zval *return_value, const rd_kafka_message_t *message)
+void kafka_message_new(zval *return_value, const rd_kafka_message_t *message, zend_string *msg_opaque)
 {
     object_init_ex(return_value, ce_kafka_message);
 
@@ -84,6 +84,10 @@ void kafka_message_new(zval *return_value, const rd_kafka_message_t *message)
         }
     }
 #endif
+
+    if (msg_opaque != NULL) {
+        zend_update_property_str(NULL, Z_RDKAFKA_PROP_OBJ(return_value), ZEND_STRL("opaque"), msg_opaque);
+    }
 }
 
 void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size) /* {{{ */
@@ -97,7 +101,7 @@ void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messag
     for (i = 0; i < size; i++) {
         msg = messages[i];
         ZVAL_NULL(&zmsg);
-        kafka_message_new(&zmsg, msg);
+        kafka_message_new(&zmsg, msg, NULL);
         add_next_index_zval(return_value, &zmsg);
     }
 } /* }}} */
@@ -161,4 +165,5 @@ void kafka_message_minit(INIT_FUNC_ARGS) { /* {{{ */
 #ifdef HAVE_RD_KAFKA_MESSAGE_HEADERS
     zend_declare_property_null(ce_kafka_message, ZEND_STRL("headers"), ZEND_ACC_PUBLIC);
 #endif
+    zend_declare_property_null(ce_kafka_message, ZEND_STRL("opaque"), ZEND_ACC_PUBLIC);
 } /* }}} */

--- a/message.h
+++ b/message.h
@@ -17,7 +17,7 @@
 */
 
 void kafka_message_minit(INIT_FUNC_ARGS);
-void kafka_message_new(zval *return_value, const rd_kafka_message_t *message);
+void kafka_message_new(zval *return_value, const rd_kafka_message_t *message, zend_string *msg_opaque);
 void kafka_message_list_to_array(zval *return_value, rd_kafka_message_t **messages, long size);
 
 extern zend_class_entry * ce_kafka_message;

--- a/php_rdkafka_priv.h
+++ b/php_rdkafka_priv.h
@@ -19,6 +19,26 @@
 #ifndef PHP_RDKAFKA_PRIV_H
 #define PHP_RDKAFKA_PRIV_H
 
+#ifndef Z_PARAM_STRING_OR_NULL
+#define Z_PARAM_STRING_OR_NULL(dest, dest_len) \
+    Z_PARAM_STRING_EX(dest, dest_len, 1, 0)
+#endif
+
+#ifndef Z_PARAM_STR_OR_NULL
+#define Z_PARAM_STR_OR_NULL(dest) \
+    Z_PARAM_STR_EX(dest, 1, 0)
+#endif
+
+#ifndef Z_PARAM_ARRAY_HT_OR_NULL
+#define Z_PARAM_ARRAY_HT_OR_NULL(dest) \
+    Z_PARAM_ARRAY_HT_EX(dest, 1, 0)
+#endif
+
+#ifndef Z_PARAM_LONG_OR_NULL
+#define Z_PARAM_LONG_OR_NULL(dest, is_null) \
+    Z_PARAM_LONG_EX(dest, is_null, 1, 0)
+#endif
+
 #if PHP_MAJOR_VERSION >= 8
 
 #define Z_RDKAFKA_OBJ zend_object

--- a/queue.c
+++ b/queue.c
@@ -112,7 +112,7 @@ PHP_METHOD(RdKafka__Queue, consume)
         return;
     }
 
-    kafka_message_new(return_value, message);
+    kafka_message_new(return_value, message, NULL);
 
     rd_kafka_message_destroy(message);
 }

--- a/tests/produce_opaque.phpt
+++ b/tests/produce_opaque.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Produce with opaque
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$opaques = [];
+$conf->setDrMsgCb(function ($producer, $msg) use (&$opaques) {
+    $opaques[] = $msg->opaque;
+});
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+$producer->flush(10*1000);
+
+var_dump($opaques);
+--EXPECT--
+array(10) {
+  [0]=>
+  string(8) "opaque 0"
+  [1]=>
+  string(8) "opaque 1"
+  [2]=>
+  string(8) "opaque 2"
+  [3]=>
+  string(8) "opaque 3"
+  [4]=>
+  string(8) "opaque 4"
+  [5]=>
+  string(8) "opaque 5"
+  [6]=>
+  string(8) "opaque 6"
+  [7]=>
+  string(8) "opaque 7"
+  [8]=>
+  string(8) "opaque 8"
+  [9]=>
+  string(8) "opaque 9"
+}

--- a/tests/produce_opaque_noconf.phpt
+++ b/tests/produce_opaque_noconf.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Produce with opaque, no conf
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+RD_KAFKA_BUILD_VERSION >= 0x1050000 && die("skip librdkafka >= 1.5.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$producer = new RdKafka\Producer();
+var_dump($producer->addBrokers(getenv('TEST_KAFKA_BROKERS')));
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+echo "Expect no leaks\n";
+--EXPECT--
+int(1)
+Expect no leaks

--- a/tests/produce_opaque_noflush.phpt
+++ b/tests/produce_opaque_noflush.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Produce with opaque, no flush
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+echo "Expect no leaks\n";
+--EXPECT--
+Expect no leaks

--- a/tests/produce_opaque_noflush_dr_callback.phpt
+++ b/tests/produce_opaque_noflush_dr_callback.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Produce with opaque, no flush, with delivery callback
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$conf->setDrMsgCb(function ($rdkafka, $msg) {
+    var_dump($rdkafka, $msg);
+});
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+echo "Expect no leaks\n";
+--EXPECT--
+Expect no leaks

--- a/tests/produce_opaque_purge.phpt
+++ b/tests/produce_opaque_purge.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Produce with opaque, purge queued/inflight messages
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+$producer->purge(RD_KAFKA_PURGE_F_QUEUE | RD_KAFKA_PURGE_F_INFLIGHT);
+
+echo "Expect no leaks\n";
+--EXPECT--
+Expect no leaks

--- a/tests/produce_opaque_purge_dr_callback.phpt
+++ b/tests/produce_opaque_purge_dr_callback.phpt
@@ -1,0 +1,39 @@
+--TEST--
+Produce with opaque, purge queued/inflight messages, with delivery callback
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$conf->setDrMsgCb(function ($rdkafka, $msg) {
+    var_dump($rdkafka, $msg);
+});
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->produce(0, 0, "message $i", null, "opaque $i");
+}
+
+$producer->purge(RD_KAFKA_PURGE_F_QUEUE | RD_KAFKA_PURGE_F_INFLIGHT);
+
+echo "Expect no leaks\n";
+--EXPECT--
+Expect no leaks

--- a/tests/producev_opaque.phpt
+++ b/tests/producev_opaque.phpt
@@ -1,0 +1,61 @@
+--TEST--
+Producev with opaque
+--SKIPIF--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+RD_KAFKA_BUILD_VERSION < 0x1000000 && die("skip librdkafka < 1.0.0");
+--FILE--
+<?php
+require __DIR__ . '/integration-tests-check.php';
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+
+$opaques = [];
+$conf->setDrMsgCb(function ($producer, $msg) use (&$opaques) {
+    $opaques[] = $msg->opaque;
+});
+
+$producer = new RdKafka\Producer($conf);
+
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+
+$topic = $producer->newTopic($topicName);
+
+if (!$producer->getMetadata(false, $topic, 2*1000)) {
+    echo "Failed to get metadata, is broker down?\n";
+}
+
+for ($i = 0; $i < 10; $i++) {
+    $topic->producev(0, 0, "message $i", null, [], 0, "opaque $i");
+}
+
+$producer->flush(10*1000);
+
+var_dump($opaques);
+--EXPECT--
+array(10) {
+  [0]=>
+  string(8) "opaque 0"
+  [1]=>
+  string(8) "opaque 1"
+  [2]=>
+  string(8) "opaque 2"
+  [3]=>
+  string(8) "opaque 3"
+  [4]=>
+  string(8) "opaque 4"
+  [5]=>
+  string(8) "opaque 5"
+  [6]=>
+  string(8) "opaque 6"
+  [7]=>
+  string(8) "opaque 7"
+  [8]=>
+  string(8) "opaque 8"
+  [9]=>
+  string(8) "opaque 9"
+}


### PR DESCRIPTION
This adds an optional `opaque` argument on `produce()`, `producev()`. The opaque value is exposed in `$message->opaque` during delivery callbacks (setDrMsgCb).

Fixes #389