### PR TITLE
Fix #491 segfault in RdKafka\TopicPartition::__construct()

### DIFF
--- a/tests/bug74.phpt
+++ b/tests/bug74.phpt
@@ -16,6 +16,6 @@ $topic = $consumer->newTopic("batman", null);
 $producer = new RdKafka\Producer($conf);
 
 if (class_exists('RdKafka\TopicPartition')) {
-    $tp = new RdKafka\TopicPartition("batman", 0, null);
+    $tp = new RdKafka\TopicPartition("batman", 0);
 }
 --EXPECT--

--- a/topic_partition.c
+++ b/topic_partition.c
@@ -207,7 +207,7 @@ PHP_METHOD(RdKafka_TopicPartition, __construct)
 
     zend_replace_error_handling(EH_THROW, spl_ce_InvalidArgumentException, &error_handling);
 
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|l!", &topic, &topic_len, &partition, &offset) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|l", &topic, &topic_len, &partition, &offset) == FAILURE) {
         zend_restore_error_handling(&error_handling);
         return;
     }

--- a/topic_partition.stub.php
+++ b/topic_partition.stub.php
@@ -10,7 +10,7 @@ namespace RdKafka;
 
 class TopicPartition
 {
-    public function __construct(string $topic, int $partition, ?int $offset = 0) {}
+    public function __construct(string $topic, int $partition, int $offset = 0) {}
 
     /** @tentative-return-type */
     public function getTopic(): ?string {}

--- a/topic_partition_arginfo.h
+++ b/topic_partition_arginfo.h
@@ -1,10 +1,10 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6724660ef71fae9d99b824c1ef54ca61adb83897 */
+ * Stub hash: 7c722b9eb9357157d89a14431ebcfd79cc6f1116 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_TopicPartition___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, topic, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, partition, IS_LONG, 0)
-	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 1, "0")
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, offset, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_TopicPartition_getTopic, 0, 0, IS_STRING, 1)

--- a/topic_partition_legacy_arginfo.h
+++ b/topic_partition_legacy_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6724660ef71fae9d99b824c1ef54ca61adb83897 */
+ * Stub hash: 7c722b9eb9357157d89a14431ebcfd79cc6f1116 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_TopicPartition___construct, 0, 0, 2)
 	ZEND_ARG_INFO(0, topic)


### PR DESCRIPTION
Drop nullable attribute, default value should be enough.

If you want to keep it, you need an additional arg to store null, and test it (probably don't worth it)
```

    if (zend_parse_parameters(ZEND_NUM_ARGS(), "sl|l!", &topic, &topic_len, &partition, &offset, &is_null) == FAILURE) {
        ...
    }
    if (is_null) {
    ....
    }
```
