### PR TITLE
Ability to provide custom `librdkafka` path during install

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -156,7 +156,9 @@
   </required>
  </dependencies>
  <providesextension>rdkafka</providesextension>
- <extsrcrelease/>
+ <extsrcrelease>
+   <configureoption name="with-rdkafka" default="autodetect" prompt="librdkafka installation path?"/>
+ </extsrcrelease>
  <changelog>
   <release>
    <date>2022-02-15</date>


### PR DESCRIPTION
Solution taken from `ssh2` extension, thanks to this I was able to install that extension with `pecl install ssh2` and provide Homebrew's path to `libssh2`.

Tested by cloning this repo, checking out `patch-1` branch and executing `pecl install package.xml`:

```
...
librdkafka installation path? [autodetect] : /opt/homebrew/opt/librdkafka
building in /private/tmp/pear/temp/pear-build-gkorbaaNXDnl/rdkafka-6.0.2
running: /private/tmp/pear/temp/rdkafka/configure --with-php-config=/opt/homebrew/opt/php@7.4/bin/php-config --with-rdkafka=/opt/homebrew/opt/librdkafka
...
Build process completed successfully
Installing '/Users/gkorba/.asdf/installs/php/7.4.30/lib/php/extensions/no-debug-non-zts-20190902/rdkafka.so'
install ok: channel://pecl.php.net/rdkafka-6.0.2
configuration option "php_ini" is not set to php.ini location
You should add "extension=rdkafka.so" to php.ini
```

It worked 🎉  

Fixes #503