### PR TITLE
Fix issue when intern->rk is never destroyed after consumer close

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -484,8 +484,11 @@ PHP_METHOD(RdKafka_KafkaConsumer, close)
         return;
     }
 
-    rd_kafka_consumer_close(intern->rk);
-    intern->rk = NULL;
+    rd_kafka_resp_err_t err = rd_kafka_consumer_close(intern->rk);
+    if (err)
+    {
+        php_error(E_WARNING, "rd_kafka_consumer_close failed: %s", rd_kafka_err2str(err));
+    }
 }
 /* }}} */
 


### PR DESCRIPTION
Because in `KafkaConsumer::close()` method the `intern->rk` is filled with NULL, it leads to not calling `rd_kafka_destroy(intern->rk)` in `kafka_consumer_free()` and eventually to incorrect librdkafka shutdown.
