### PR TITLE
Fix kafka consumer left undestroyed in close

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -485,6 +485,7 @@ PHP_METHOD(RdKafka_KafkaConsumer, close)
     }
 
     rd_kafka_consumer_close(intern->rk);
+    rd_kafka_destroy(intern->rk);
     intern->rk = NULL;
 }
 /* }}} */


### PR DESCRIPTION
Calling close and not destroying underlying kafka consumer leads to unclean librdkafka shutdown and very often to segfaults. 