### PR TITLE
Fix kafka consumer not destroyed in close

### DIFF
--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -536,6 +536,7 @@ PHP_METHOD(RdKafka_KafkaConsumer, close)
     }
 
     rd_kafka_consumer_close(intern->rk);
+    rd_kafka_destroy(intern->rk);
     intern->rk = NULL;
 }
 /* }}} */

--- a/tests/kafka_consumer_close_destroy.phpt
+++ b/tests/kafka_consumer_close_destroy.phpt
@@ -1,0 +1,27 @@
+--TEST--
+KafkaConsumer::close() followed by object destruction does not segfault
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+
+// Reproduce bug where close() called rd_kafka_consumer_close() and set rk=NULL
+// without calling rd_kafka_destroy(), causing the destructor to skip cleanup
+// and resulting in an unclean librdkafka shutdown / segfault.
+for ($i = 0; $i < 5; $i++) {
+    $conf = new RdKafka\Conf();
+    $conf->set('group.id', sprintf('test_close_destroy_%s', uniqid()));
+    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+    $conf->setLogCb(function ($kafka, $level, $facility, $message) {});
+
+    $consumer = new RdKafka\KafkaConsumer($conf);
+    $consumer->subscribe([sprintf('test_rdkafka_%s', uniqid())]);
+    $consumer->close();
+    unset($consumer);
+}
+
+echo "OK\n";
+--EXPECT--
+OK


### PR DESCRIPTION
Not destroying underlying kafka consumer in close() method leads to unclean librdkafka shutdown and very often to segfaults.