### PR TITLE
Fix segmentation fault in setOauthbearerTokenRefreshCb when sasl.oauthbearer.config is unset (#567)

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -365,7 +365,10 @@ static void kafka_conf_set_oauthbearer_token_refresh_cb(rd_kafka_t *rk, const ch
     ZVAL_NULL(&args[1]);
 
     ZVAL_ZVAL(&args[0], &cbs->zrk, 1, 0);
-    ZVAL_STRING(&args[1], oauthbearer_config);
+
+    if (oauthbearer_config) {
+        ZVAL_STRING(&args[1], oauthbearer_config);
+    }
 
     rdkafka_call_function(&cbs->oauthbearer_token_refresh->fci, &cbs->oauthbearer_token_refresh->fcc, NULL, 2, args);
 

--- a/package.xml
+++ b/package.xml
@@ -118,6 +118,7 @@
     <file role="test" name="bug465.phpt"/>
     <file role="test" name="bug508.phpt"/>
     <file role="test" name="bug521.phpt"/>
+    <file role="test" name="bug567.phpt"/>
     <file role="test" name="bug74.phpt"/>
     <file role="test" name="bug88.phpt"/>
     <file role="test" name="bugConfSetArgument.phpt"/>

--- a/tests/bug567.phpt
+++ b/tests/bug567.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Bug #567
+--SKIPIF--
+<?php
+RD_KAFKA_VERSION >= 0x01010000 || die("skip librdkafka too old does not support oauthbearer");
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+if (RD_KAFKA_VERSION >= 0x090000 && false !== getenv('TEST_KAFKA_BROKER_VERSION')) {
+    $conf->set('broker.version.fallback', getenv('TEST_KAFKA_BROKER_VERSION'));
+}
+
+$conf->set('metadata.broker.list', 'foobar');
+$conf->set('security.protocol', 'SASL_PLAINTEXT');
+$conf->set('sasl.mechanisms', 'OAUTHBEARER');
+$conf->setOauthbearerTokenRefreshCb(function ($producer) {
+    echo "oauthbearer token refresh callback successfully called\n";
+});
+$producer = new \RdKafka\Producer($conf);
+$producer->poll(0);
+echo "producer polled successfully\n";
+
+--EXPECT--
+oauthbearer token refresh callback successfully called
+producer polled successfully


### PR DESCRIPTION
Only call `ZVAL_STRING` for `&args[1]` with `oauthbearer_config` if `oauthbearer_config` is set in `kafka_conf_set_oauthbearer_token_refresh_cb`

Fixes #567