### PR TITLE
Fix compiler deprecation warnings for rd_kafka_set_logger and rd_kafka_errno2err

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -52,6 +52,13 @@ KafkaConsumer::oauthbearerSetTokenFailure(string $error): void
 
 `poll()` allows the high-level consumer to service callbacks (including the OAUTHBEARER token refresh callback) without consuming a message. This is the same method that exists on the low-level `RdKafka\Consumer`.
 
+### `RdKafka::setLogger()` and `rd_kafka_errno2err()` are deprecated
+
+Both `RdKafka::setLogger()` and `rd_kafka_errno2err()` are deprecated in librdkafka and will be removed in a future version. Calling them now emits an `E_DEPRECATED` notice.
+
+- Replace `$producer->setLogger(RD_KAFKA_LOG_PRINT)` (and similar) with `$conf->setLogCb(callable $callback)` set before constructing the producer or consumer.
+- Replace `rd_kafka_errno2err($errno)` with `rd_kafka_last_error()`, which returns the last error code set by librdkafka directly without requiring an errno argument.
+
 ### SASL/SSL OAUTHBEARER support for `KafkaConsumer`
 
 `RdKafka\KafkaConsumer` now fully supports OAUTHBEARER authentication, including over SASL_SSL. Set `setOauthbearerTokenRefreshCb()` on the `Conf` and use the new `oauthbearerSetToken()` / `oauthbearerSetTokenFailure()` methods on the consumer instance to provide tokens.

--- a/fun.c
+++ b/fun.c
@@ -136,7 +136,10 @@ PHP_FUNCTION(rd_kafka_errno2err)
         return;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     RETURN_LONG(rd_kafka_errno2err(errnox));
+#pragma GCC diagnostic pop
 }
 /* }}} */
 

--- a/rdkafka.c
+++ b/rdkafka.c
@@ -738,7 +738,10 @@ PHP_METHOD(RdKafka, setLogger)
             return;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     rd_kafka_set_logger(intern->rk, logger);
+#pragma GCC diagnostic pop
 }
 /* }}} */
 

--- a/tests/deprecated_errno2err.phpt
+++ b/tests/deprecated_errno2err.phpt
@@ -1,0 +1,17 @@
+--TEST--
+rd_kafka_errno2err() emits E_DEPRECATED
+--FILE--
+<?php
+set_error_handler(function (int $errno, string $errstr): bool {
+    if ($errno === E_DEPRECATED) {
+        echo "Deprecated: $errstr\n";
+    }
+    return true;
+}, E_DEPRECATED);
+
+$result = rd_kafka_errno2err(0);
+
+echo "OK\n";
+--EXPECT--
+Deprecated: Function rd_kafka_errno2err() is deprecated
+OK

--- a/tests/deprecated_set_logger.phpt
+++ b/tests/deprecated_set_logger.phpt
@@ -1,0 +1,21 @@
+--TEST--
+RdKafka::setLogger() emits E_DEPRECATED
+--FILE--
+<?php
+set_error_handler(function (int $errno, string $errstr): bool {
+    if ($errno === E_DEPRECATED) {
+        echo "Deprecated: $errstr\n";
+    }
+    return true;
+}, E_DEPRECATED);
+
+$conf = new RdKafka\Conf();
+$conf->setLogCb(function () {});
+$producer = new RdKafka\Producer($conf);
+$producer->setLogger(RD_KAFKA_LOG_PRINT);
+
+echo "OK\n";
+--EXPECTF--
+Deprecated: Method RdKafka::setLogger() is deprecated
+OK
+%A


### PR DESCRIPTION
Fixes #548

`rd_kafka_set_logger()` and `rd_kafka_errno2err()` are marked deprecated in librdkafka, causing `-Wdeprecated-declarations` compiler warnings. Both are already marked deprecated at the PHP level via the arginfo (`ZEND_ACC_DEPRECATED / ZEND_DEP_FE`), so users already receive `E_DEPRECATED` notices at runtime.

The C call sites are wrapped with `#pragma GCC diagnostic` to suppress the compiler warnings while keeping the existing behavior intact. Tests added to confirm the runtime deprecation notices are emitted correctly.

Once upstream finally removes the deprecated calls, we can conditionally remove calls in php-rdkakfa (version dependent)