### PR TITLE
Fix missing rd_kafka_topic_destroy() in KafkaConsumer::newTopic() destructor

### DIFF
--- a/tests/kafka_consumer_new_topic_no_memleak.phpt
+++ b/tests/kafka_consumer_new_topic_no_memleak.phpt
@@ -1,0 +1,25 @@
+--TEST--
+KafkaConsumer::newTopic() does not leak the rd_kafka_topic_t handle on destruction
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+
+for ($i = 0; $i < 5; $i++) {
+    $conf = new RdKafka\Conf();
+    $conf->set('group.id', sprintf('test_new_topic_memleak_%s', uniqid()));
+    $conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+    $conf->setLogCb(function () {});
+
+    $consumer = new RdKafka\KafkaConsumer($conf);
+    $topic = $consumer->newTopic('test_rdkafka_new_topic_memleak');
+    unset($topic);
+    $consumer->close();
+    unset($consumer);
+}
+
+echo "OK\n";
+--EXPECT--
+OK

--- a/topic.c
+++ b/topic.c
@@ -53,6 +53,8 @@ static void kafka_topic_free(zend_object *object) /* {{{ */
         if (kafka_intern) {
             zend_hash_index_del(&kafka_intern->topics, (zend_ulong)intern);
         }
+    } else if (intern->rkt) {
+        rd_kafka_topic_destroy(intern->rkt);
     }
 
     zend_object_std_dtor(&intern->std);


### PR DESCRIPTION
When a topic is created via `KafkaConsumer::newTopic()`, the `kafka_topic_free()` handler never calls `rd_kafka_topic_destroy()` on the underlying handle. The existing cleanup path only runs when `zrk` is set... which is only the case for topics created via the low-level Consumer or Producer.  Topics created via KafkaConsumer leave zrk unset, so the rkt handle was silently leaked.

The fix is a one-liner: add an `else if` branch to call `rd_kafka_topic_destroy()` when `zrk` is unset but `rkt` is not.

Unfortunately, the included regression test cannot demonstrate the leak via valgrind (librdkafka's `rd_kafka_destroy()` cleans up all associated topic handles when the consumer is destroyed so valgrind sees no leaked memory at exit). The leak is observable via ASAN, which tracks allocation ownership more precisely and was the original reporter's tool in #533. The test serves as a guard that this code path doesn't crash or regress.

Fixes #533.