### PR TITLE
Add Conf::get() and TopicConf::get()

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -433,6 +433,58 @@ PHP_METHOD(RdKafka_Conf, dump)
 }
 /* }}} */
 
+/* {{{ proto string RdKafka\Conf::get(string $name)
+   Retrieve a configuration property value. */
+PHP_METHOD(RdKafka_Conf, get)
+{
+    char *name;
+    size_t name_len;
+    kafka_conf_object *intern;
+    char *dest;
+    size_t dest_size;
+    rd_kafka_conf_res_t ret;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_conf_object(getThis());
+    if (!intern) {
+        return;
+    }
+
+    switch (intern->type) {
+        case KAFKA_CONF:
+            ret = rd_kafka_conf_get(intern->u.conf, name, NULL, &dest_size);
+            break;
+        case KAFKA_TOPIC_CONF:
+            ret = rd_kafka_topic_conf_get(intern->u.topic_conf, name, NULL, &dest_size);
+            break;
+        default:
+            return;
+    }
+
+    if (ret == RD_KAFKA_CONF_UNKNOWN) {
+        zend_throw_exception_ex(ce_kafka_exception, RD_KAFKA_CONF_UNKNOWN, "Unknown configuration property \"%s\"", name);
+        return;
+    }
+
+    dest = emalloc(dest_size);
+
+    switch (intern->type) {
+        case KAFKA_CONF:
+            rd_kafka_conf_get(intern->u.conf, name, dest, &dest_size);
+            break;
+        case KAFKA_TOPIC_CONF:
+            rd_kafka_topic_conf_get(intern->u.topic_conf, name, dest, &dest_size);
+            break;
+    }
+
+    RETVAL_STRING(dest);
+    efree(dest);
+}
+/* }}} */
+
 /* {{{ proto void RdKafka\Conf::set(string $name, string $value)
    Sets a configuration property. */
 PHP_METHOD(RdKafka_Conf, set)

--- a/conf.stub.php
+++ b/conf.stub.php
@@ -16,6 +16,9 @@ class Conf
     public function dump(): array {}
 
     /** @tentative-return-type */
+    public function get(string $name): string {}
+
+    /** @tentative-return-type */
     public function set(string $name, string $value): void {}
 
     /**
@@ -58,6 +61,12 @@ class TopicConf
      * @implementation-alias RdKafka\Conf::dump
      */
     public function dump(): array {}
+
+    /**
+     * @tentative-return-type
+     * @implementation-alias RdKafka\Conf::get
+     */
+    public function get(string $name): string {}
 
     /**
      * @tentative-return-type

--- a/conf_arginfo.h
+++ b/conf_arginfo.h
@@ -1,5 +1,4 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 4bdaeef0f9a2a0194b1f800100ff14793cf6980a */
+/* This is a generated file, edit the .stub.php file instead. */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf___construct, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -9,6 +8,14 @@ ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_Conf_dum
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_dump, 0, 0, 0)
 #endif
+ZEND_END_ARG_INFO()
+
+#if (PHP_VERSION_ID >= 80100)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_Conf_get, 0, 1, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_get, 0, 0, 1)
+#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
 #if (PHP_VERSION_ID >= 80100)
@@ -54,6 +61,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RdKafka_TopicConf_dump arginfo_class_RdKafka_Conf_dump
 
+#define arginfo_class_RdKafka_TopicConf_get arginfo_class_RdKafka_Conf_get
+
 #define arginfo_class_RdKafka_TopicConf_set arginfo_class_RdKafka_Conf_set
 
 #if (PHP_VERSION_ID >= 80100)
@@ -67,6 +76,7 @@ ZEND_END_ARG_INFO()
 
 ZEND_METHOD(RdKafka_Conf, __construct);
 ZEND_METHOD(RdKafka_Conf, dump);
+ZEND_METHOD(RdKafka_Conf, get);
 ZEND_METHOD(RdKafka_Conf, set);
 ZEND_METHOD(RdKafka_Conf, setDefaultTopicConf);
 ZEND_METHOD(RdKafka_Conf, setErrorCb);
@@ -84,6 +94,7 @@ ZEND_METHOD(RdKafka_TopicConf, setPartitioner);
 static const zend_function_entry class_RdKafka_Conf_methods[] = {
 	ZEND_ME(RdKafka_Conf, __construct, arginfo_class_RdKafka_Conf___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, dump, arginfo_class_RdKafka_Conf_dump, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_Conf, get, arginfo_class_RdKafka_Conf_get, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, set, arginfo_class_RdKafka_Conf_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, setDefaultTopicConf, arginfo_class_RdKafka_Conf_setDefaultTopicConf, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME(RdKafka_Conf, setErrorCb, arginfo_class_RdKafka_Conf_setErrorCb, ZEND_ACC_PUBLIC)
@@ -101,6 +112,7 @@ static const zend_function_entry class_RdKafka_Conf_methods[] = {
 static const zend_function_entry class_RdKafka_TopicConf_methods[] = {
 	ZEND_ME(RdKafka_TopicConf, __construct, arginfo_class_RdKafka_TopicConf___construct, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(RdKafka_Conf, dump, dump, arginfo_class_RdKafka_TopicConf_dump, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(RdKafka_Conf, get, get, arginfo_class_RdKafka_TopicConf_get, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(RdKafka_Conf, set, set, arginfo_class_RdKafka_TopicConf_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_TopicConf, setPartitioner, arginfo_class_RdKafka_TopicConf_setPartitioner, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/tests/conf_get.phpt
+++ b/tests/conf_get.phpt
@@ -1,0 +1,35 @@
+--TEST--
+RdKafka\Conf::get() and RdKafka\TopicConf::get() retrieve configuration values
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+$conf->set('group.id', 'test-group');
+var_dump($conf->get('group.id'));
+
+$conf->set('socket.timeout.ms', '1234');
+var_dump($conf->get('socket.timeout.ms'));
+
+// Unknown property throws
+try {
+    $conf->get('does.not.exist');
+} catch (RdKafka\Exception $e) {
+    echo "Exception: " . $e->getMessage() . "\n";
+}
+
+$topicConf = new RdKafka\TopicConf();
+$topicConf->set('request.timeout.ms', '5678');
+var_dump($topicConf->get('request.timeout.ms'));
+
+// Unknown topic property throws
+try {
+    $topicConf->get('does.not.exist');
+} catch (RdKafka\Exception $e) {
+    echo "Exception: " . $e->getMessage() . "\n";
+}
+--EXPECT--
+string(10) "test-group"
+string(4) "1234"
+Exception: Unknown configuration property "does.not.exist"
+string(4) "5678"
+Exception: Unknown configuration property "does.not.exist"


### PR DESCRIPTION
Adds a `get(string $name)`: string method to both `RdKafka\Conf` and `RdKafka\TopicConf`, wrapping `rd_kafka_conf_get()` and `rd_kafka_topic_conf_get()` respectively.

Currently the only way to read back a config value is dump(), which returns everything. This gives you a single property without the overhead of dumping the full config.

Throws `RdKafka\Exception` for unknown property names, consistent with how set() handles unknown properties.

Also note: like set(), `rd_kafka_conf_get()` always returns string values regardless of the underlying type.

Fixes #527 
Fixes #525