### PR TITLE
KafkaConsumer::consume() returns null on poll timeout (breaking change)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,12 @@ package.xml
 rdkafka-*.tgz
 run-tests.php
 gen_stub.php
+tests/*.diff
+tests/*.exp
+tests/*.log
+tests/*.out
+tests/*.php
+tests/*.sh
 tests/*/*.diff
 tests/*/*.exp
 tests/*/*.log

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -16,6 +16,28 @@
 
 ## User-impacting changes
 
+### `KafkaConsumer::consume()` returns `null` on timeout
+
+Previously, `KafkaConsumer::consume()` returned a `Message` object with `err` set to `RD_KAFKA_RESP_ERR__TIMED_OUT` when no message arrived within the timeout window. It now returns `null` in that case, matching librdkafka's own behavior.
+
+**Before:**
+```php
+$msg = $consumer->consume(1000);
+if ($msg->err === RD_KAFKA_RESP_ERR__TIMED_OUT) {
+    // no message
+}
+```
+
+**After:**
+```php
+$msg = $consumer->consume(1000);
+if ($msg === null) {
+    // no message
+}
+```
+
+`RD_KAFKA_RESP_ERR__TIMED_OUT` on a returned `Message` now means an actual timeout error originating from librdkafka, not a poll window expiry.
+
 ### PHP 8.1 now required
 
 php-rdkafka 7.x requires PHP 8.1 or later. PHP 7.x is no longer supported.

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -392,13 +392,13 @@ PHP_METHOD(RdKafka_KafkaConsumer, unsubscribe)
 }
 /* }}} */
 
-/* {{{ proto Message RdKafka\KafkaConsumer::consume()
-   Consume message or get error event, triggers callbacks */
+/* {{{ proto ?Message RdKafka\KafkaConsumer::consume()
+   Consume message or get error event, triggers callbacks. Returns null if no message is available within timeout_ms. */
 PHP_METHOD(RdKafka_KafkaConsumer, consume)
 {
     object_intern *intern;
     zend_long timeout_ms;
-    rd_kafka_message_t *rkmessage, rkmessage_tmp = {0};
+    rd_kafka_message_t *rkmessage;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &timeout_ms) == FAILURE) {
         return;
@@ -412,15 +412,11 @@ PHP_METHOD(RdKafka_KafkaConsumer, consume)
     rkmessage = rd_kafka_consumer_poll(intern->rk, timeout_ms);
 
     if (!rkmessage) {
-        rkmessage_tmp.err = RD_KAFKA_RESP_ERR__TIMED_OUT;
-        rkmessage = &rkmessage_tmp;
+        RETURN_NULL();
     }
 
     kafka_message_new(return_value, rkmessage, NULL);
-
-    if (rkmessage != &rkmessage_tmp) {
-        rd_kafka_message_destroy(rkmessage);
-    }
+    rd_kafka_message_destroy(rkmessage);
 }
 /* }}} */
 

--- a/kafka_consumer.stub.php
+++ b/kafka_consumer.stub.php
@@ -42,7 +42,7 @@ class KafkaConsumer
     public function commitAsync(Message|array|null $message_or_offsets = null): void {}
 
     /** @tentative-return-type */
-    public function consume(int $timeout_ms): Message {}
+    public function consume(int $timeout_ms): ?Message {}
 
     /** @tentative-return-type */
     public function subscribe(array $topics): void {}

--- a/kafka_consumer_arginfo.h
+++ b/kafka_consumer_arginfo.h
@@ -52,7 +52,7 @@ ZEND_END_ARG_INFO()
 #define arginfo_class_RdKafka_KafkaConsumer_commitAsync arginfo_class_RdKafka_KafkaConsumer_commit
 
 #if (PHP_VERSION_ID >= 80100)
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_consume, 0, 1, RdKafka\\Message, 0)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_consume, 0, 1, RdKafka\\Message, 1)
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_consume, 0, 0, 1)
 #endif

--- a/tests/kafka_consumer_consume_returns_message_on_eof.phpt
+++ b/tests/kafka_consumer_consume_returns_message_on_eof.phpt
@@ -1,0 +1,52 @@
+--TEST--
+KafkaConsumer::consume() returns a Message (not null) on partition EOF
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+
+$topic = sprintf('test_rdkafka_%s', uniqid());
+
+// Seed one message
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->setLogCb(function () {});
+$conf->setDrMsgCb(function () {});
+$producer = new RdKafka\Producer($conf);
+$producer->newTopic($topic)->produce(RD_KAFKA_PARTITION_UA, 0, 'seed');
+$producer->flush(5000);
+unset($producer);
+
+// Consume from earliest with partition EOF enabled
+$conf = new RdKafka\Conf();
+$conf->set('group.id', sprintf('test_rdkafka_%s', uniqid()));
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->set('auto.offset.reset', 'earliest');
+$conf->set('enable.partition.eof', 'true');
+$conf->setLogCb(function () {});
+
+$consumer = new RdKafka\KafkaConsumer($conf);
+$consumer->subscribe([$topic]);
+
+// Consume the seeded message
+while (true) {
+    $msg = $consumer->consume(5000);
+    if ($msg === null) {
+        continue;
+    }
+    if ($msg->err === RD_KAFKA_RESP_ERR_NO_ERROR) {
+        break;
+    }
+}
+
+// Next consume should hit EOF — must be a Message, not null
+$eof = $consumer->consume(5000);
+var_dump($eof instanceof RdKafka\Message);
+var_dump($eof->err === RD_KAFKA_RESP_ERR__PARTITION_EOF);
+
+$consumer->close();
+--EXPECT--
+bool(true)
+bool(true)

--- a/tests/kafka_consumer_consume_returns_null_on_timeout.phpt
+++ b/tests/kafka_consumer_consume_returns_null_on_timeout.phpt
@@ -1,0 +1,37 @@
+--TEST--
+KafkaConsumer::consume() returns null when no message is available within timeout
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+
+$topic = sprintf('test_rdkafka_%s', uniqid());
+
+// Seed the topic so it exists on the broker
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->setLogCb(function () {});
+$conf->setDrMsgCb(function () {});
+$producer = new RdKafka\Producer($conf);
+$producer->newTopic($topic)->produce(RD_KAFKA_PARTITION_UA, 0, 'seed');
+$producer->flush(5000);
+unset($producer);
+
+// Subscribe at latest — no new messages, so consume() should return null
+$conf = new RdKafka\Conf();
+$conf->set('group.id', sprintf('test_rdkafka_%s', uniqid()));
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->set('auto.offset.reset', 'latest');
+$conf->setLogCb(function () {});
+
+$consumer = new RdKafka\KafkaConsumer($conf);
+$consumer->subscribe([$topic]);
+
+$msg = $consumer->consume(3000);
+var_dump($msg);
+
+$consumer->close();
+--EXPECT--
+NULL

--- a/tests/oauthbearer_integration_hl.phpt
+++ b/tests/oauthbearer_integration_hl.phpt
@@ -101,7 +101,7 @@ $consumer->subscribe([$topicName]);
 echo "Reading data\n";
 
 $message = $consumer->consume(10*1000);
-echo $message->err === -185 ? "Received empty message when reading data after not setting or refreshing any token\n" :
+echo $message === null ? "Received empty message when reading data after not setting or refreshing any token\n" :
     "FAIL: Did receive a message after not setting or refreshing any token\n";
 
 // Test that metadata will be loaded before data consumption, under the condition that poll is called


### PR DESCRIPTION
Previously, `KafkaConsumer::consume()` returned a Message object with `err` set to `RD_KAFKA_RESP_ERR__TIMED_OUT` (-185) when no message arrived within the timeout window. This was a php-rdkafka-ism... librdkafka itself returns `NULL` in that case.

This made it impossible to distinguish "nothing arrived during the poll window" from an actual `RD_KAFKA_RESP_ERR__TIMED_OUT` error originating from librdkafka. The return type is now `?Message`, returning `null` when the poll window expires with no message.

Note: A test for a real `RD_KAFKA_RESP_ERR__TIMED_OUT` coming back inside a Message isn't included here... reliably triggering a broker-level timeout in a test environment isn't practical without introducing flakiness.

Before:
```php
$msg = $consumer->consume(1000);
if ($msg->err === RD_KAFKA_RESP_ERR__TIMED_OUT) {
    // no message — but was this a real timeout error or just an empty poll?
}
```

After:
```php
$msg = $consumer->consume(1000);
if ($msg === null) {
    // no message in the poll window
}
```

`RD_KAFKA_RESP_ERR__TIMED_OUT` on a returned `Message` now means an actual timeout error from librdkafka, not a poll window expiry.

Existing tests updated: Any test previously checking `$msg->err === RD_KAFKA_RESP_ERR__TIMED_OUT` (or -185) to detect an empty poll has been updated to check `$msg === null` instead.

Closes #343.