### PR TITLE
Add TopicPartition::getMetadata() and setMetadata()

### DIFF
--- a/tests/topic_partition_metadata.phpt
+++ b/tests/topic_partition_metadata.phpt
@@ -1,0 +1,33 @@
+--TEST--
+TopicPartition get/set metadata
+--SKIPIF--
+<?php
+if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
+--FILE--
+<?php
+$tp = new RdKafka\TopicPartition('test-topic', 0, 100);
+
+// default is null
+var_dump($tp->getMetadata());
+
+// set a string value
+$result = $tp->setMetadata('my-metadata');
+var_dump($result === $tp); // fluent interface
+
+var_dump($tp->getMetadata());
+
+// set binary metadata
+$tp->setMetadata("\x00\x01\x02\x03");
+var_dump(strlen($tp->getMetadata()));
+var_dump($tp->getMetadata() === "\x00\x01\x02\x03");
+
+// clear with null
+$tp->setMetadata(null);
+var_dump($tp->getMetadata());
+--EXPECT--
+NULL
+bool(true)
+string(11) "my-metadata"
+int(4)
+bool(true)
+NULL

--- a/topic_partition.c
+++ b/topic_partition.c
@@ -47,6 +47,10 @@ static void free_object(zend_object *object) /* {{{ */
         efree(intern->topic);
     }
 
+    if (intern->metadata) {
+        efree(intern->metadata);
+    }
+
     zend_object_std_dtor(&intern->std);
 }
 /* }}} */
@@ -141,10 +145,17 @@ void kafka_topic_partition_list_to_array(zval *return_value, rd_kafka_topic_part
     array_init_size(return_value, list->cnt);
 
     for (i = 0; i < list->cnt; i++) {
+        object_intern *tp_intern;
         topar = &list->elems[i];
         ZVAL_NULL(&ztopar);
         object_init_ex(&ztopar, ce_kafka_topic_partition);
         kafka_topic_partition_init(&ztopar, topar->topic, topar->partition, topar->offset, topar->err);
+        if (topar->metadata_size > 0 && topar->metadata) {
+            tp_intern = Z_RDKAFKA_P(object_intern, &ztopar);
+            tp_intern->metadata = emalloc(topar->metadata_size);
+            memcpy(tp_intern->metadata, topar->metadata, topar->metadata_size);
+            tp_intern->metadata_size = topar->metadata_size;
+        }
         add_next_index_zval(return_value, &ztopar);
     }
 } /* }}} */
@@ -184,6 +195,11 @@ rd_kafka_topic_partition_list_t * array_arg_to_kafka_topic_partition_list(int ar
 
         topar = rd_kafka_topic_partition_list_add(list, topar_intern->topic, topar_intern->partition);
         topar->offset = topar_intern->offset;
+        if (topar_intern->metadata && topar_intern->metadata_size > 0) {
+            topar->metadata = malloc(topar_intern->metadata_size);
+            memcpy(topar->metadata, topar_intern->metadata, topar_intern->metadata_size);
+            topar->metadata_size = topar_intern->metadata_size;
+        }
     }
 
     return list;
@@ -361,6 +377,62 @@ PHP_METHOD(RdKafka_TopicPartition, getErr)
     }
 
     RETURN_LONG((zend_long) intern->err);
+}
+/* }}} */
+
+/* {{{ proto ?string RdKafka\TopicPartition::getMetadata()
+   Returns committed offset metadata */
+PHP_METHOD(RdKafka_TopicPartition, getMetadata)
+{
+    object_intern *intern;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    intern = get_object(getThis());
+    if (!intern) {
+        return;
+    }
+
+    if (intern->metadata) {
+        RETURN_STRINGL(intern->metadata, intern->metadata_size);
+    } else {
+        RETURN_NULL();
+    }
+}
+/* }}} */
+
+/* {{{ proto TopicPartition RdKafka\TopicPartition::setMetadata(?string $metadata)
+   Sets committed offset metadata */
+PHP_METHOD(RdKafka_TopicPartition, setMetadata)
+{
+    char *metadata = NULL;
+    size_t metadata_len = 0;
+    object_intern *intern;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s!", &metadata, &metadata_len) == FAILURE) {
+        return;
+    }
+
+    intern = get_object(getThis());
+    if (!intern) {
+        return;
+    }
+
+    if (intern->metadata) {
+        efree(intern->metadata);
+        intern->metadata = NULL;
+        intern->metadata_size = 0;
+    }
+
+    if (metadata) {
+        intern->metadata = emalloc(metadata_len);
+        memcpy(intern->metadata, metadata, metadata_len);
+        intern->metadata_size = metadata_len;
+    }
+
+    RETURN_ZVAL(getThis(), 1, 0);
 }
 /* }}} */
 

--- a/topic_partition.h
+++ b/topic_partition.h
@@ -21,6 +21,8 @@ typedef struct _kafka_topic_partition_intern {
     int32_t     partition;
     int64_t     offset;
     rd_kafka_resp_err_t err;
+    char        *metadata;
+    size_t      metadata_size;
     zend_object std;
 } kafka_topic_partition_intern;
 

--- a/topic_partition.stub.php
+++ b/topic_partition.stub.php
@@ -32,4 +32,10 @@ class TopicPartition
 
     /** @tentative-return-type */
     public function getErr(): ?int {}
+
+    /** @tentative-return-type */
+    public function getMetadata(): ?string {}
+
+    /** @tentative-return-type */
+    public function setMetadata(?string $metadata): TopicPartition {}
 }

--- a/topic_partition_arginfo.h
+++ b/topic_partition_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 0000000000000000000000000000000000000000 */
+ * Stub hash: 7c722b9eb9357157d89a14431ebcfd79cc6f1116 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_TopicPartition___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, topic, IS_STRING, 0)

--- a/topic_partition_arginfo.h
+++ b/topic_partition_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 7c722b9eb9357157d89a14431ebcfd79cc6f1116 */
+ * Stub hash: 0000000000000000000000000000000000000000 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_TopicPartition___construct, 0, 0, 2)
 	ZEND_ARG_TYPE_INFO(0, topic, IS_STRING, 0)
@@ -30,6 +30,13 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_TopicPartition_getErr, 0, 0, IS_LONG, 1)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_TopicPartition_getMetadata, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_TopicPartition_setMetadata, 0, 1, RdKafka\\TopicPartition, 0)
+	ZEND_ARG_TYPE_INFO(0, metadata, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
 
 ZEND_METHOD(RdKafka_TopicPartition, __construct);
 ZEND_METHOD(RdKafka_TopicPartition, getTopic);
@@ -39,6 +46,8 @@ ZEND_METHOD(RdKafka_TopicPartition, setPartition);
 ZEND_METHOD(RdKafka_TopicPartition, getOffset);
 ZEND_METHOD(RdKafka_TopicPartition, setOffset);
 ZEND_METHOD(RdKafka_TopicPartition, getErr);
+ZEND_METHOD(RdKafka_TopicPartition, getMetadata);
+ZEND_METHOD(RdKafka_TopicPartition, setMetadata);
 
 
 static const zend_function_entry class_RdKafka_TopicPartition_methods[] = {
@@ -50,6 +59,8 @@ static const zend_function_entry class_RdKafka_TopicPartition_methods[] = {
 	ZEND_ME(RdKafka_TopicPartition, getOffset, arginfo_class_RdKafka_TopicPartition_getOffset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_TopicPartition, setOffset, arginfo_class_RdKafka_TopicPartition_setOffset, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_TopicPartition, getErr, arginfo_class_RdKafka_TopicPartition_getErr, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_TopicPartition, getMetadata, arginfo_class_RdKafka_TopicPartition_getMetadata, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_TopicPartition, setMetadata, arginfo_class_RdKafka_TopicPartition_setMetadata, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 


### PR DESCRIPTION
Adds `getMetadata()` and `setMetadata()` to `RdKafka\TopicPartition`, exposing the `metadata` / `metadata_size` fields that librdkafka has always carried on `rd_kafka_topic_partition_t` but that we never wired up.

With this in place you can attach an arbitrary string to an offset commit...

```php
$tp = new RdKafka\TopicPartition('my-topic', 0, $offset);
$tp->setMetadata('{"processed_at":"2026-04-25"}');
$consumer->commit([$tp]);
```

Then read it back later via getCommittedOffsets(). The value is binary-safe and nullable (setMetadata(null) clears it). The fluent interface matches the existing setter pattern on the class.

Metadata is correctly round-tripped in both directions: kafka_topic_partition_list_to_array() copies metadata from librdkafka partitions into PHP objects, and array_arg_to_kafka_topic_partition_list() copies it back out (using malloc so librdkafka can free it when the list is destroyed).

`tests/topic_partition_metadata.phpt` covers null default, fluent return, string round-trip, binary safety, and null-to-clear

closes #336