### PR TITLE
Include topic-level properties in Conf::dump()

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -410,26 +410,38 @@ PHP_METHOD(RdKafka_Conf, dump)
         return;
     }
 
+    array_init(return_value);
+
     switch (intern->type) {
-        case KAFKA_CONF:
+        case KAFKA_CONF: {
+            rd_kafka_topic_conf_t *topic_conf;
+
             dump = rd_kafka_conf_dump(intern->u.conf, &cntp);
+            for (i = 0; i < cntp; i+=2) {
+                add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
+            }
+            rd_kafka_conf_dump_free(dump, cntp);
+
+            topic_conf = rd_kafka_conf_get_default_topic_conf(intern->u.conf);
+            if (topic_conf) {
+                dump = rd_kafka_topic_conf_dump(topic_conf, &cntp);
+                for (i = 0; i < cntp; i+=2) {
+                    add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
+                }
+                rd_kafka_conf_dump_free(dump, cntp);
+            }
             break;
+        }
         case KAFKA_TOPIC_CONF:
             dump = rd_kafka_topic_conf_dump(intern->u.topic_conf, &cntp);
+            for (i = 0; i < cntp; i+=2) {
+                add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
+            }
+            rd_kafka_conf_dump_free(dump, cntp);
             break;
         default:
             return;
     }
-
-    array_init(return_value);
-
-    for (i = 0; i < cntp; i+=2) {
-        const char *key = dump[i];
-        const char *value = dump[i+1];
-        add_assoc_string(return_value, (char*)key, (char*)value);
-    }
-
-    rd_kafka_conf_dump_free(dump, cntp);
 }
 /* }}} */
 

--- a/conf.c
+++ b/conf.c
@@ -99,7 +99,7 @@ static void kafka_conf_free(zend_object *object) /* {{{ */
             kafka_conf_callbacks_dtor(&intern->cbs);
             break;
         case KAFKA_TOPIC_CONF:
-            if (intern->u.topic_conf) {
+            if (intern->u.topic_conf && !intern->is_borrowed) {
                 rd_kafka_topic_conf_destroy(intern->u.topic_conf);
             }
             break;
@@ -410,38 +410,108 @@ PHP_METHOD(RdKafka_Conf, dump)
         return;
     }
 
-    array_init(return_value);
-
     switch (intern->type) {
-        case KAFKA_CONF: {
-            rd_kafka_topic_conf_t *topic_conf;
-
+        case KAFKA_CONF:
             dump = rd_kafka_conf_dump(intern->u.conf, &cntp);
-            for (i = 0; i < cntp; i+=2) {
-                add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
-            }
-            rd_kafka_conf_dump_free(dump, cntp);
-
-            topic_conf = rd_kafka_conf_get_default_topic_conf(intern->u.conf);
-            if (topic_conf) {
-                dump = rd_kafka_topic_conf_dump(topic_conf, &cntp);
-                for (i = 0; i < cntp; i+=2) {
-                    add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
-                }
-                rd_kafka_conf_dump_free(dump, cntp);
-            }
             break;
-        }
         case KAFKA_TOPIC_CONF:
             dump = rd_kafka_topic_conf_dump(intern->u.topic_conf, &cntp);
-            for (i = 0; i < cntp; i+=2) {
-                add_assoc_string(return_value, (char*)dump[i], (char*)dump[i+1]);
-            }
-            rd_kafka_conf_dump_free(dump, cntp);
             break;
         default:
             return;
     }
+
+    array_init(return_value);
+
+    for (i = 0; i < cntp; i+=2) {
+        const char *key = dump[i];
+        const char *value = dump[i+1];
+        add_assoc_string(return_value, (char*)key, (char*)value);
+    }
+
+    rd_kafka_conf_dump_free(dump, cntp);
+}
+/* }}} */
+
+/* {{{ proto string RdKafka\Conf::get(string $name)
+   Retrieve a single configuration property value. */
+PHP_METHOD(RdKafka_Conf, get)
+{
+    char *name;
+    size_t name_len;
+    kafka_conf_object *intern;
+    char *dest;
+    size_t dest_size;
+    rd_kafka_conf_res_t ret;
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &name, &name_len) == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_conf_object(getThis());
+    if (!intern) {
+        return;
+    }
+
+    switch (intern->type) {
+        case KAFKA_CONF:
+            ret = rd_kafka_conf_get(intern->u.conf, name, NULL, &dest_size);
+            break;
+        case KAFKA_TOPIC_CONF:
+            ret = rd_kafka_topic_conf_get(intern->u.topic_conf, name, NULL, &dest_size);
+            break;
+        default:
+            return;
+    }
+
+    if (ret == RD_KAFKA_CONF_UNKNOWN) {
+        zend_throw_exception_ex(ce_kafka_exception, RD_KAFKA_CONF_UNKNOWN, "Unknown configuration property \"%s\"", name);
+        return;
+    }
+
+    dest = emalloc(dest_size);
+
+    switch (intern->type) {
+        case KAFKA_CONF:
+            rd_kafka_conf_get(intern->u.conf, name, dest, &dest_size);
+            break;
+        case KAFKA_TOPIC_CONF:
+            rd_kafka_topic_conf_get(intern->u.topic_conf, name, dest, &dest_size);
+            break;
+    }
+
+    RETVAL_STRING(dest);
+    efree(dest);
+}
+/* }}} */
+
+/* {{{ proto ?TopicConf RdKafka\Conf::getDefaultTopicConf()
+   Returns the default topic conf embedded in this Conf, or null if none exists. */
+PHP_METHOD(RdKafka_Conf, getDefaultTopicConf)
+{
+    kafka_conf_object *intern;
+    kafka_conf_object *topic_intern;
+    rd_kafka_topic_conf_t *topic_conf;
+
+    if (zend_parse_parameters_none() == FAILURE) {
+        return;
+    }
+
+    intern = get_kafka_conf_object(getThis());
+    if (!intern || intern->type != KAFKA_CONF) {
+        return;
+    }
+
+    topic_conf = rd_kafka_conf_get_default_topic_conf(intern->u.conf);
+    if (!topic_conf) {
+        RETURN_NULL();
+    }
+
+    object_init_ex(return_value, ce_kafka_topic_conf);
+    topic_intern = Z_RDKAFKA_P(kafka_conf_object, return_value);
+    topic_intern->type = KAFKA_TOPIC_CONF;
+    topic_intern->is_borrowed = 1;
+    topic_intern->u.topic_conf = topic_conf;
 }
 /* }}} */
 

--- a/conf.h
+++ b/conf.h
@@ -51,6 +51,7 @@ typedef struct _kafka_conf_callbacks {
 
 typedef struct _kafka_conf_object {
     kafka_conf_type type;
+    int             is_borrowed;
     union {
         rd_kafka_conf_t         *conf;
         rd_kafka_topic_conf_t   *topic_conf;

--- a/conf.stub.php
+++ b/conf.stub.php
@@ -16,6 +16,12 @@ class Conf
     public function dump(): array {}
 
     /** @tentative-return-type */
+    public function get(string $name): string {}
+
+    /** @tentative-return-type */
+    public function getDefaultTopicConf(): ?TopicConf {}
+
+    /** @tentative-return-type */
     public function set(string $name, string $value): void {}
 
     /**
@@ -58,6 +64,12 @@ class TopicConf
      * @implementation-alias RdKafka\Conf::dump
      */
     public function dump(): array {}
+
+    /**
+     * @tentative-return-type
+     * @implementation-alias RdKafka\Conf::get
+     */
+    public function get(string $name): string {}
 
     /**
      * @tentative-return-type

--- a/conf_arginfo.h
+++ b/conf_arginfo.h
@@ -12,6 +12,21 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_dump, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
 #if (PHP_VERSION_ID >= 80100)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_Conf_get, 0, 1, IS_STRING, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_get, 0, 0, 1)
+#endif
+	ZEND_ARG_TYPE_INFO(0, name, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#if (PHP_VERSION_ID >= 80100)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_Conf_getDefaultTopicConf, 0, 0, RdKafka\\TopicConf, 1)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_getDefaultTopicConf, 0, 0, 0)
+#endif
+ZEND_END_ARG_INFO()
+
+#if (PHP_VERSION_ID >= 80100)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_Conf_set, 0, 2, IS_VOID, 0)
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_Conf_set, 0, 0, 2)
@@ -54,6 +69,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_RdKafka_TopicConf_dump arginfo_class_RdKafka_Conf_dump
 
+#define arginfo_class_RdKafka_TopicConf_get arginfo_class_RdKafka_Conf_get
+
 #define arginfo_class_RdKafka_TopicConf_set arginfo_class_RdKafka_Conf_set
 
 #if (PHP_VERSION_ID >= 80100)
@@ -67,6 +84,8 @@ ZEND_END_ARG_INFO()
 
 ZEND_METHOD(RdKafka_Conf, __construct);
 ZEND_METHOD(RdKafka_Conf, dump);
+ZEND_METHOD(RdKafka_Conf, get);
+ZEND_METHOD(RdKafka_Conf, getDefaultTopicConf);
 ZEND_METHOD(RdKafka_Conf, set);
 ZEND_METHOD(RdKafka_Conf, setDefaultTopicConf);
 ZEND_METHOD(RdKafka_Conf, setErrorCb);
@@ -84,6 +103,8 @@ ZEND_METHOD(RdKafka_TopicConf, setPartitioner);
 static const zend_function_entry class_RdKafka_Conf_methods[] = {
 	ZEND_ME(RdKafka_Conf, __construct, arginfo_class_RdKafka_Conf___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, dump, arginfo_class_RdKafka_Conf_dump, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_Conf, get, arginfo_class_RdKafka_Conf_get, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_Conf, getDefaultTopicConf, arginfo_class_RdKafka_Conf_getDefaultTopicConf, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, set, arginfo_class_RdKafka_Conf_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_Conf, setDefaultTopicConf, arginfo_class_RdKafka_Conf_setDefaultTopicConf, ZEND_ACC_PUBLIC|ZEND_ACC_DEPRECATED)
 	ZEND_ME(RdKafka_Conf, setErrorCb, arginfo_class_RdKafka_Conf_setErrorCb, ZEND_ACC_PUBLIC)
@@ -101,6 +122,7 @@ static const zend_function_entry class_RdKafka_Conf_methods[] = {
 static const zend_function_entry class_RdKafka_TopicConf_methods[] = {
 	ZEND_ME(RdKafka_TopicConf, __construct, arginfo_class_RdKafka_TopicConf___construct, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(RdKafka_Conf, dump, dump, arginfo_class_RdKafka_TopicConf_dump, ZEND_ACC_PUBLIC)
+	ZEND_MALIAS(RdKafka_Conf, get, get, arginfo_class_RdKafka_TopicConf_get, ZEND_ACC_PUBLIC)
 	ZEND_MALIAS(RdKafka_Conf, set, set, arginfo_class_RdKafka_TopicConf_set, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_TopicConf, setPartitioner, arginfo_class_RdKafka_TopicConf_setPartitioner, ZEND_ACC_PUBLIC)
 	ZEND_FE_END

--- a/tests/conf_dump.phpt
+++ b/tests/conf_dump.phpt
@@ -1,0 +1,29 @@
+--TEST--
+RdKafka\Conf::dump includes topic-level properties
+--SKIPIF--
+<?php
+if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
+--FILE--
+<?php
+$conf = new RdKafka\Conf();
+
+// global-level property
+$conf->set('socket.timeout.ms', '60000');
+
+// topic-level property (stored in the embedded default_topic_conf)
+$conf->set('auto.offset.reset', 'earliest');
+
+$dump = $conf->dump();
+
+var_dump(isset($dump['socket.timeout.ms']));
+var_dump(isset($dump['auto.offset.reset']));
+
+// TopicConf::dump() should still work independently
+$topicConf = new RdKafka\TopicConf();
+$topicConf->set('auto.offset.reset', 'latest');
+$topicDump = $topicConf->dump();
+var_dump(isset($topicDump['auto.offset.reset']));
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)

--- a/tests/conf_dump.phpt
+++ b/tests/conf_dump.phpt
@@ -1,29 +1,36 @@
 --TEST--
-RdKafka\Conf::dump includes topic-level properties
+RdKafka\Conf::dump returns global properties only; topic-level properties via getDefaultTopicConf()
 --SKIPIF--
 <?php
 if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
 --FILE--
 <?php
 $conf = new RdKafka\Conf();
-
-// global-level property
-$conf->set('socket.timeout.ms', '60000');
-
-// topic-level property (stored in the embedded default_topic_conf)
-$conf->set('auto.offset.reset', 'earliest');
+$conf->set('group.id', 'test-group');         // global
+$conf->set('auto.offset.reset', 'earliest'); // topic-level
 
 $dump = $conf->dump();
 
-var_dump(isset($dump['socket.timeout.ms']));
+// global property appears in dump()
+var_dump(isset($dump['group.id']));
+
+// topic-level property does NOT appear in dump()
 var_dump(isset($dump['auto.offset.reset']));
 
-// TopicConf::dump() should still work independently
-$topicConf = new RdKafka\TopicConf();
-$topicConf->set('auto.offset.reset', 'latest');
+// topic-level property is accessible via getDefaultTopicConf()
+$topicConf = $conf->getDefaultTopicConf();
+var_dump($topicConf instanceof RdKafka\TopicConf);
 $topicDump = $topicConf->dump();
 var_dump(isset($topicDump['auto.offset.reset']));
+
+// TopicConf::dump() still works independently
+$standalone = new RdKafka\TopicConf();
+$standalone->set('auto.offset.reset', 'latest');
+$standaloneDump = $standalone->dump();
+var_dump(isset($standaloneDump['auto.offset.reset']));
 --EXPECT--
+bool(true)
+bool(false)
 bool(true)
 bool(true)
 bool(true)

--- a/tests/conf_get.phpt
+++ b/tests/conf_get.phpt
@@ -1,0 +1,37 @@
+--TEST--
+RdKafka\Conf::get() and RdKafka\TopicConf::get() retrieve configuration values
+--SKIPIF--
+<?php
+if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
+--FILE--
+<?php
+$conf = new RdKafka\Conf();
+$conf->set('group.id', 'test-group');
+var_dump($conf->get('group.id'));
+
+$conf->set('message.max.bytes', '2000000');
+var_dump($conf->get('message.max.bytes'));
+
+// Unknown property throws
+try {
+    $conf->get('does.not.exist');
+} catch (RdKafka\Exception $e) {
+    echo "Exception: " . $e->getMessage() . "\n";
+}
+
+$topicConf = new RdKafka\TopicConf();
+$topicConf->set('request.timeout.ms', '5678');
+var_dump($topicConf->get('request.timeout.ms'));
+
+// Unknown topic property throws
+try {
+    $topicConf->get('does.not.exist');
+} catch (RdKafka\Exception $e) {
+    echo "Exception: " . $e->getMessage() . "\n";
+}
+--EXPECT--
+string(10) "test-group"
+string(7) "2000000"
+Exception: Unknown configuration property "does.not.exist"
+string(4) "5678"
+Exception: Unknown configuration property "does.not.exist"

--- a/tests/conf_get_default_topic_conf.phpt
+++ b/tests/conf_get_default_topic_conf.phpt
@@ -1,0 +1,32 @@
+--TEST--
+RdKafka\Conf::getDefaultTopicConf() returns null when no topic properties set, TopicConf otherwise
+--SKIPIF--
+<?php
+if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
+--FILE--
+<?php
+// Returns null when no topic-level properties have been set
+$conf = new RdKafka\Conf();
+var_dump($conf->getDefaultTopicConf());
+
+// Returns a TopicConf once a topic-level property is set
+$conf->set('auto.offset.reset', 'earliest');
+$topicConf = $conf->getDefaultTopicConf();
+var_dump($topicConf instanceof RdKafka\TopicConf);
+
+// get() works on the returned TopicConf
+var_dump($topicConf->get('auto.offset.reset'));
+
+// dump() works on the returned TopicConf
+$dump = $topicConf->dump();
+var_dump(isset($dump['auto.offset.reset']));
+
+// The returned TopicConf is a live view — changes via Conf::set() are reflected
+$conf->set('auto.offset.reset', 'latest');
+var_dump($topicConf->get('auto.offset.reset'));
+--EXPECT--
+NULL
+bool(true)
+string(8) "smallest"
+bool(true)
+string(7) "largest"


### PR DESCRIPTION
After feedback from @arnaud-lb, this takes a different direction than originally proposed.

Instead of silently merging topic-level properties into `Conf::dump()`, this PR:

- Adds `Conf::get(string $name): string` and `TopicConf::get(string $name): string` — fetch a single config value directly, throwing `RdKafka\Exception` for unknown properties
- Adds `Conf::getDefaultTopicConf(): ?TopicConf` — exposes the embedded default topic conf so topic-level properties can be read explicitly via `->dump()` or `->get()`

`dump()` behavior is unchanged. The pattern for reading topic-level properties is now:

```php
$conf->set('auto.offset.reset', 'earliest');

$conf->get('group.id');                             // global property
$conf->getDefaultTopicConf()->get('auto.offset.reset'); // topic-level property
```

Closes #306, #527, #525.


~~`Conf::dump()` was only dumping the global `rd_kafka_conf_t` settings. Properties like `auto.offset.reset` are routed by librdkafka into the embedded `default_topic_conf`, so they were silently missing from the output... which made dump() unreliable for debugging.~~

~~The fix calls `rd_kafka_conf_get_default_topic_conf()` after the global dump and, if a default topic conf exists, merges its entries into the same array. `TopicConf::dump()` is unchanged.~~
