### PR TITLE
Improve callback tests, remove risky skip

### DIFF
--- a/tests/callback_dr_msg_cb_args.phpt
+++ b/tests/callback_dr_msg_cb_args.phpt
@@ -1,0 +1,44 @@
+--TEST--
+Conf::setDrMsgCb fires with correct Message arguments
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+--FILE--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+
+$deliveries = [];
+
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
+$conf->setLogCb(function () {});
+$conf->setDrMsgCb(function ($producer, $msg) use (&$deliveries) {
+    $deliveries[] = [
+        'producer_type' => get_class($producer),
+        'msg_type'      => get_class($msg),
+        'err'           => $msg->err,
+        'topic'         => $msg->topic_name,
+        'payload'       => $msg->payload,
+    ];
+});
+
+$producer = new RdKafka\Producer($conf);
+$topicName = sprintf("test_rdkafka_%s", uniqid());
+$topic = $producer->newTopic($topicName);
+
+$topic->produce(RD_KAFKA_PARTITION_UA, 0, 'hello-dr-msg');
+$producer->flush(10000);
+
+var_dump(count($deliveries) === 1);
+var_dump($deliveries[0]['producer_type']);
+var_dump($deliveries[0]['msg_type']);
+var_dump($deliveries[0]['err'] === RD_KAFKA_RESP_ERR_NO_ERROR);
+var_dump($deliveries[0]['topic']);
+var_dump($deliveries[0]['payload']);
+--EXPECTF--
+bool(true)
+string(16) "RdKafka\Producer"
+string(15) "RdKafka\Message"
+bool(true)
+string(%d) "test_rdkafka_%s"
+string(12) "hello-dr-msg"

--- a/tests/callback_log_cb.phpt
+++ b/tests/callback_log_cb.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Conf::setLogCb fires with correct arguments
+--SKIPIF--
+<?php
+if (!extension_loaded('rdkafka')) die('skip rdkafka extension not loaded');
+--FILE--
+<?php
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', 'localhost:9999');
+$conf->set('debug', 'generic');
+
+$calls = [];
+$conf->setLogCb(function ($kafka, $level, $facility, $message) use (&$calls) {
+    $calls[] = [
+        'kafka_type'    => get_class($kafka),
+        'level_is_int'  => is_int($level),
+        'facility_type' => gettype($facility),
+        'message_type'  => gettype($message),
+    ];
+});
+
+$producer = new RdKafka\Producer($conf);
+$producer->poll(0);
+
+var_dump(count($calls) > 0);
+var_dump($calls[0]['kafka_type']);
+var_dump($calls[0]['level_is_int']);
+var_dump($calls[0]['facility_type']);
+var_dump($calls[0]['message_type']);
+--EXPECT--
+bool(true)
+string(16) "RdKafka\Producer"
+bool(true)
+string(6) "string"
+string(6) "string"

--- a/tests/conf_callbacks_integration.phpt
+++ b/tests/conf_callbacks_integration.phpt
@@ -1,8 +1,7 @@
 --TEST--
-RdKafka\Conf
+Conf callbacks: offsetCommitCb and statsCb fire correctly
 --SKIPIF--
 <?php
-!getenv('TESTS_DONT_SKIP_RISKY') && die("skip Risky/broken test");
 require __DIR__ . '/helpers/integration-tests-check.php';
 --FILE--
 <?php
@@ -25,9 +24,6 @@ for ($i = 0; $i < 10; $i++) {
 while ($producer->getOutQLen()) {
     $producer->poll(50);
 }
-
-// Make sure there is enough time for the stats_cb to pick up the consumer lag
-sleep(1);
 
 $conf = new RdKafka\Conf();
 
@@ -65,6 +61,12 @@ while (true) {
     }
 
     $consumer->commit($msg);
+}
+
+// Poll until statsCb fires (statistics.interval.ms=10 so it should be near-immediate)
+$deadline = time() + 5;
+while (!$statsCbCalled && time() < $deadline) {
+    $consumer->poll(100);
 }
 
 var_dump($statsCbCalled);


### PR DESCRIPTION
- Removes the `TESTS_DONT_SKIP_RISKY` gate from `conf_callbacks_integration.phpt` and replaces the `sleep(1)` hack with a poll loop, so the stats callback test is no longer racy
- Adds `callback_log_cb.phpt` — verifies `setLogCb` fires with the correct argument types (no broker required)
- Adds `callback_dr_msg_cb_args.phpt` — verifies `setDrMsgCb` delivers a properly populated `Message` with `err=0`, correct topic, and correct payload

closes #277