### PR TITLE
release/7.0.0alpha1

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,8 @@
   <email>arnaud.lb@gmail.com</email>
   <active>yes</active>
  </lead>
- <date>2026-04-20</date>
+ <date>2026-05-07</date>
+ <time>17:42:14</time>
  <version>
   <release>7.0.0alpha1</release>
   <api>7.0.0</api>
@@ -21,10 +22,24 @@
  </stability>
  <license uri="http://opensource.org/licenses/mit-license.php">MIT License</license>
  <notes>
-  ## Bug fixes
-  - Fix php 7.0 build (#563, @arnaud-lb)
-  - Fix x32 build (#565, @arnaud-lb)
-  - Fix segmentation fault in setOauthbearerTokenRefreshCb when sasl.oauthbearer.config is unset (#568, @scorgn)
+  ## Other Changes
+  - Drop unsupported php versions and old librdkafka versions (#559, @arnaud-lb)
+  - Fix types (#560, @arnaud-lb)
+  - Cleanup php 7 compatibility code (#564, @arnaud-lb)
+  - Run workflows on Ubuntu 24 (#583, @arnaud-lb)
+  - SASL_SSL OAUTHBEARER support for high level consumer (#581, @Rastusik)
+  - Docker environment for local development, fix tests so artifacts and helpers don't get deleted (#593, @ralphschindler)
+  - Fix kafka consumer not destroyed in close (#540, @ikeberlein)
+  - add UPGRADE.md  (#594, @ralphschindler)
+  - Fix missing rd_kafka_topic_destroy() in KafkaConsumer::newTopic() destructor (#598, @ralphschindler)
+  - Fix compiler deprecation warnings for rd_kafka_set_logger and rd_kafka_errno2err (#596, @ralphschindler)
+  - KafkaConsumer::consume() returns null on poll timeout (breaking change) (#600, @ralphschindler)
+  - Improve callback tests, remove risky skip (#603, @ralphschindler)
+  - Add TopicPartition::getMetadata() and setMetadata() (#601, @ralphschindler)
+  - Include topic-level properties in Conf::dump() (#602, @ralphschindler)
+  - transactional consume-transform-produce loop (#597, @ralphschindler)
+  - update for pie installation (#604, @ralphschindler)
+  - Fix PIE configure option: needs-value should be true for path-accepting options (#605, @ralphschindler)
  </notes>
  <contents>
   <dir name="/">
@@ -170,6 +185,25 @@
    <configureoption name="with-rdkafka" default="autodetect" prompt="librdkafka installation path?"/>
  </extsrcrelease>
  <changelog>
+  <release>
+   <date>2024-11-04</date>
+   <time>11:24:15</time>
+   <version>
+    <release>6.0.5</release>
+    <api>6.0.0</api>
+   </version>
+   <stability>
+    <release>stable</release>
+    <api>stable</api>
+   </stability>
+   <license uri="http://opensource.org/licenses/mit-license.php">MIT License</license>
+   <notes>
+    ## Bug fixes
+    - Fix php 7.0 build (#563, @arnaud-lb)
+    - Fix x32 build (#565, @arnaud-lb)
+    - Fix segmentation fault in setOauthbearerTokenRefreshCb when sasl.oauthbearer.config is unset (#568, @scorgn)
+   </notes>
+  </release>
   <release>
    <date>2024-10-24</date>
    <time>14:56:47</time>

--- a/tools/new-package-release.php
+++ b/tools/new-package-release.php
@@ -31,7 +31,7 @@ function printUsage(): void
 function generateReleaseNotes(string $newVersion): string
 {
     $cmd = sprintf(
-        'gh api repos/arnaud-lb/php-rdkafka/releases/generate-notes -f tag_name=%s -f target_commitish=%s',
+        'gh api repos/php-rdkafka/php-rdkafka/releases/generate-notes -f tag_name=%s -f target_commitish=%s',
         escapeshellcmd($newVersion),
         escapeshellcmd(exec("git rev-parse HEAD")),
     );
@@ -70,6 +70,25 @@ function generateReleaseNotes(string $newVersion): string
     return implode("\n", $newLines);
 }
 
+function deriveApiVersion(string $version): string
+{
+    if (!preg_match('/^(\d+)\.(\d+)/', $version, $m)) {
+        throw new \Exception("Cannot derive api version from $version");
+    }
+    return sprintf('%d.%d.0', $m[1], $m[2]);
+}
+
+function deriveStability(string $version): string
+{
+    if (preg_match('/(alpha|devel)/i', $version)) {
+        return 'alpha';
+    }
+    if (preg_match('/(beta|RC)/i', $version)) {
+        return 'beta';
+    }
+    return 'stable';
+}
+
 function updateCurrentRelease(DOMDocument $doc, string $newVersion, string $releaseNotes): void
 {
     $date = date('Y-m-d');
@@ -83,6 +102,15 @@ function updateCurrentRelease(DOMDocument $doc, string $newVersion, string $rele
 
     $versionElem = findOneElement($doc, '/ns:package/ns:version/ns:release');
     replaceContent($versionElem, $doc->createTextNode($newVersion));
+
+    $apiElem = findOneElement($doc, '/ns:package/ns:version/ns:api');
+    replaceContent($apiElem, $doc->createTextNode(deriveApiVersion($newVersion)));
+
+    $stability = deriveStability($newVersion);
+    $stabilityReleaseElem = findOneElement($doc, '/ns:package/ns:stability/ns:release');
+    replaceContent($stabilityReleaseElem, $doc->createTextNode($stability));
+    $stabilityApiElem = findOneElement($doc, '/ns:package/ns:stability/ns:api');
+    replaceContent($stabilityApiElem, $doc->createTextNode($stability));
 
     $notesElem = findOneElement($doc, '/ns:package/ns:notes');
     $releaseNotes = rtrim("\n  " . str_replace("\n", "\n  ", $releaseNotes))."\n ";

--- a/tools/prepare-release.sh
+++ b/tools/prepare-release.sh
@@ -3,7 +3,7 @@
 set -e
 
 version="$1"
-baseBranch=6.x
+baseBranch=7.x
 
 if [[ -z "$version" ]]; then
     printf "Missing version parameter" >&2
@@ -16,7 +16,7 @@ echo "Updating package.xml"
 pecl package-validate
 
 echo "Updating PHP_RDKAFKA_VERSION"
-sed -i 's/#define PHP_RDKAFKA_VERSION.*/#define PHP_RDKAFKA_VERSION "'"$1"'"/' php_rdkafka.h
+sed -i.bak 's/#define PHP_RDKAFKA_VERSION.*/#define PHP_RDKAFKA_VERSION "'"$1"'"/' php_rdkafka.h && rm php_rdkafka.h.bak
 
 echo "Printing diff"
 git diff


### PR DESCRIPTION
## Summary
- First 7.0 alpha release. Updates `package.xml` with the 7.0.0alpha1 entry (notes auto-generated from GitHub release notes API) and bumps `PHP_RDKAFKA_VERSION`.
- Hardens `tools/new-package-release.php` to also update `<api>` version and `<stability>` based on the new version string (previously only `<release>` and `<notes>` were updated, leaving stale `6.0.0`/`stable` values when bumping major version or stability).
- Fixes `tools/prepare-release.sh` for macOS BSD sed (`sed -i.bak ... && rm`), and corrects `baseBranch` to `7.x`.

## Test plan
- [x] `pecl package-validate` passes
- [x] `pecl package` produces `rdkafka-7.0.0alpha1.tgz`
- [x] Tarball installs via `pecl install ./rdkafka-7.0.0alpha1.tgz` against a librdkafka-equipped system
- [ ] Upload `.tgz` to pecl.php.net after merge + tag push