### PR TITLE
Add `KafkaConsumer::getRebalanceProtocol()`

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -77,6 +77,12 @@ if test "$PHP_RDKAFKA" != "no"; then
     AC_MSG_WARN([no rd_kafka_consumer_group_metadata_group_id, ConsumerGroupMetadata getters not available (requires librdkafka >= 2.8.0)])
   ])
 
+  AC_CHECK_LIB($LIBNAME,[rd_kafka_rebalance_protocol],[
+    AC_DEFINE(HAS_RD_KAFKA_REBALANCE_PROTOCOL,1,[ ])
+  ],[
+    AC_MSG_WARN([no rd_kafka_rebalance_protocol, KafkaConsumer::getRebalanceProtocol() not available (requires librdkafka >= 1.6.0)])
+  ])
+
   LDFLAGS="$ORIG_LDFLAGS"
   CPPFLAGS="$ORIG_CPPFLAGS"
 

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -944,12 +944,12 @@ PHP_METHOD(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure)
 }
 /* }}} */
 
-/* {{{ proto string|null RdKafka\KafkaConsumer::getRebalanceProtocol()
+#ifdef HAS_RD_KAFKA_REBALANCE_PROTOCOL
+/* {{{ proto string RdKafka\KafkaConsumer::getRebalanceProtocol()
    Returns the current consumer group rebalance protocol ("NONE", "EAGER", or "COOPERATIVE") */
 PHP_METHOD(RdKafka_KafkaConsumer, getRebalanceProtocol)
 {
     object_intern *intern;
-    const char *protocol;
 
     ZEND_PARSE_PARAMETERS_NONE();
 
@@ -958,15 +958,10 @@ PHP_METHOD(RdKafka_KafkaConsumer, getRebalanceProtocol)
         return;
     }
 
-    protocol = rd_kafka_rebalance_protocol(intern->rk);
-
-    if (protocol == NULL) {
-        RETURN_NULL();
-    }
-
-    RETURN_STRING(protocol);
+    RETURN_STRING(rd_kafka_rebalance_protocol(intern->rk));
 }
 /* }}} */
+#endif
 
 /* {{{ proto RdKafka\ConsumerGroupMetadata RdKafka\KafkaConsumer::getConsumerGroupMetadata() */
 PHP_METHOD(RdKafka_KafkaConsumer, getConsumerGroupMetadata)

--- a/kafka_consumer.c
+++ b/kafka_consumer.c
@@ -944,6 +944,30 @@ PHP_METHOD(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure)
 }
 /* }}} */
 
+/* {{{ proto string|null RdKafka\KafkaConsumer::getRebalanceProtocol()
+   Returns the current consumer group rebalance protocol ("NONE", "EAGER", or "COOPERATIVE") */
+PHP_METHOD(RdKafka_KafkaConsumer, getRebalanceProtocol)
+{
+    object_intern *intern;
+    const char *protocol;
+
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    intern = get_object(getThis());
+    if (!intern) {
+        return;
+    }
+
+    protocol = rd_kafka_rebalance_protocol(intern->rk);
+
+    if (protocol == NULL) {
+        RETURN_NULL();
+    }
+
+    RETURN_STRING(protocol);
+}
+/* }}} */
+
 /* {{{ proto RdKafka\ConsumerGroupMetadata RdKafka\KafkaConsumer::getConsumerGroupMetadata() */
 PHP_METHOD(RdKafka_KafkaConsumer, getConsumerGroupMetadata)
 {

--- a/kafka_consumer.stub.php
+++ b/kafka_consumer.stub.php
@@ -90,7 +90,7 @@ class KafkaConsumer
     public function oauthbearerSetTokenFailure(string $error): void {}
 
     /** @tentative-return-type */
-    public function getRebalanceProtocol(): ?string {}
+    public function getRebalanceProtocol(): string {}
 
     /** @tentative-return-type */
     public function getConsumerGroupMetadata(): ConsumerGroupMetadata {}

--- a/kafka_consumer.stub.php
+++ b/kafka_consumer.stub.php
@@ -90,5 +90,8 @@ class KafkaConsumer
     public function oauthbearerSetTokenFailure(string $error): void {}
 
     /** @tentative-return-type */
+    public function getRebalanceProtocol(): ?string {}
+
+    /** @tentative-return-type */
     public function getConsumerGroupMetadata(): ConsumerGroupMetadata {}
 }

--- a/kafka_consumer_arginfo.h
+++ b/kafka_consumer_arginfo.h
@@ -152,12 +152,14 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetTokenFa
 	ZEND_ARG_TYPE_INFO(0, error, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if defined(HAS_RD_KAFKA_REBALANCE_PROTOCOL)
 #if (PHP_VERSION_ID >= 80100)
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, 0, 0, IS_STRING, 1)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, 0, 0, IS_STRING, 0)
 #else
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, 0, 0, 0)
 #endif
 ZEND_END_ARG_INFO()
+#endif
 
 #if (PHP_VERSION_ID >= 80100)
 ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, 0, 0, RdKafka\\ConsumerGroupMetadata, 0)
@@ -192,7 +194,9 @@ ZEND_METHOD(RdKafka_KafkaConsumer, resumePartitions);
 ZEND_METHOD(RdKafka_KafkaConsumer, poll);
 ZEND_METHOD(RdKafka_KafkaConsumer, oauthbearerSetToken);
 ZEND_METHOD(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure);
+#if defined(HAS_RD_KAFKA_REBALANCE_PROTOCOL)
 ZEND_METHOD(RdKafka_KafkaConsumer, getRebalanceProtocol);
+#endif
 ZEND_METHOD(RdKafka_KafkaConsumer, getConsumerGroupMetadata);
 
 static const zend_function_entry class_RdKafka_KafkaConsumer_methods[] = {
@@ -222,7 +226,9 @@ static const zend_function_entry class_RdKafka_KafkaConsumer_methods[] = {
 	ZEND_ME(RdKafka_KafkaConsumer, poll, arginfo_class_RdKafka_KafkaConsumer_poll, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, oauthbearerSetToken, arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetToken, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure, arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetTokenFailure, ZEND_ACC_PUBLIC)
+#if defined(HAS_RD_KAFKA_REBALANCE_PROTOCOL)
 	ZEND_ME(RdKafka_KafkaConsumer, getRebalanceProtocol, arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, ZEND_ACC_PUBLIC)
+#endif
 	ZEND_ME(RdKafka_KafkaConsumer, getConsumerGroupMetadata, arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };

--- a/kafka_consumer_arginfo.h
+++ b/kafka_consumer_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 6ebc69a2e5c4d2a7815e02ebebc84d54b93d01ec */
+ * Stub hash: fb8f1a9814fd536f198b3c13a269b16c74ac45a8 */
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer___construct, 0, 0, 1)
 	ZEND_ARG_OBJ_INFO(0, conf, RdKafka\\Conf, 0)
@@ -21,9 +21,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_incrementalAssign, 0,
 #endif
 	ZEND_ARG_TYPE_INFO(0, topic_partitions, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
-#endif
 
-#if defined(HAS_RD_KAFKA_INCREMENTAL_ASSIGN)
 #define arginfo_class_RdKafka_KafkaConsumer_incrementalUnassign arginfo_class_RdKafka_KafkaConsumer_incrementalAssign
 #endif
 
@@ -154,13 +152,24 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetTokenFa
 	ZEND_ARG_TYPE_INFO(0, error, IS_STRING, 0)
 ZEND_END_ARG_INFO()
 
+#if (PHP_VERSION_ID >= 80100)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_TYPE_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, 0, 0, IS_STRING, 1)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, 0, 0, 0)
+#endif
+ZEND_END_ARG_INFO()
+
+#if (PHP_VERSION_ID >= 80100)
+ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, 0, 0, RdKafka\\ConsumerGroupMetadata, 0)
+#else
+ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, 0, 0, 0)
+#endif
+ZEND_END_ARG_INFO()
 
 ZEND_METHOD(RdKafka_KafkaConsumer, __construct);
 ZEND_METHOD(RdKafka_KafkaConsumer, assign);
 #if defined(HAS_RD_KAFKA_INCREMENTAL_ASSIGN)
 ZEND_METHOD(RdKafka_KafkaConsumer, incrementalAssign);
-#endif
-#if defined(HAS_RD_KAFKA_INCREMENTAL_ASSIGN)
 ZEND_METHOD(RdKafka_KafkaConsumer, incrementalUnassign);
 #endif
 ZEND_METHOD(RdKafka_KafkaConsumer, getAssignment);
@@ -183,23 +192,14 @@ ZEND_METHOD(RdKafka_KafkaConsumer, resumePartitions);
 ZEND_METHOD(RdKafka_KafkaConsumer, poll);
 ZEND_METHOD(RdKafka_KafkaConsumer, oauthbearerSetToken);
 ZEND_METHOD(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure);
+ZEND_METHOD(RdKafka_KafkaConsumer, getRebalanceProtocol);
 ZEND_METHOD(RdKafka_KafkaConsumer, getConsumerGroupMetadata);
-
-#if (PHP_VERSION_ID >= 80100)
-ZEND_BEGIN_ARG_WITH_TENTATIVE_RETURN_OBJ_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, 0, 0, RdKafka\\ConsumerGroupMetadata, 0)
-#else
-ZEND_BEGIN_ARG_INFO_EX(arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, 0, 0, 0)
-#endif
-ZEND_END_ARG_INFO()
-
 
 static const zend_function_entry class_RdKafka_KafkaConsumer_methods[] = {
 	ZEND_ME(RdKafka_KafkaConsumer, __construct, arginfo_class_RdKafka_KafkaConsumer___construct, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, assign, arginfo_class_RdKafka_KafkaConsumer_assign, ZEND_ACC_PUBLIC)
 #if defined(HAS_RD_KAFKA_INCREMENTAL_ASSIGN)
 	ZEND_ME(RdKafka_KafkaConsumer, incrementalAssign, arginfo_class_RdKafka_KafkaConsumer_incrementalAssign, ZEND_ACC_PUBLIC)
-#endif
-#if defined(HAS_RD_KAFKA_INCREMENTAL_ASSIGN)
 	ZEND_ME(RdKafka_KafkaConsumer, incrementalUnassign, arginfo_class_RdKafka_KafkaConsumer_incrementalUnassign, ZEND_ACC_PUBLIC)
 #endif
 	ZEND_ME(RdKafka_KafkaConsumer, getAssignment, arginfo_class_RdKafka_KafkaConsumer_getAssignment, ZEND_ACC_PUBLIC)
@@ -222,6 +222,7 @@ static const zend_function_entry class_RdKafka_KafkaConsumer_methods[] = {
 	ZEND_ME(RdKafka_KafkaConsumer, poll, arginfo_class_RdKafka_KafkaConsumer_poll, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, oauthbearerSetToken, arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetToken, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, oauthbearerSetTokenFailure, arginfo_class_RdKafka_KafkaConsumer_oauthbearerSetTokenFailure, ZEND_ACC_PUBLIC)
+	ZEND_ME(RdKafka_KafkaConsumer, getRebalanceProtocol, arginfo_class_RdKafka_KafkaConsumer_getRebalanceProtocol, ZEND_ACC_PUBLIC)
 	ZEND_ME(RdKafka_KafkaConsumer, getConsumerGroupMetadata, arginfo_class_RdKafka_KafkaConsumer_getConsumerGroupMetadata, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
@@ -231,7 +232,11 @@ static zend_class_entry *register_class_RdKafka_KafkaConsumer(void)
 	zend_class_entry ce, *class_entry;
 
 	INIT_NS_CLASS_ENTRY(ce, "RdKafka", "KafkaConsumer", class_RdKafka_KafkaConsumer_methods);
+#if (PHP_VERSION_ID >= 80400)
+	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
+#else
 	class_entry = zend_register_internal_class_ex(&ce, NULL);
+#endif
 
 	zval property_error_cb_default_value;
 	ZVAL_UNDEF(&property_error_cb_default_value);

--- a/package.xml
+++ b/package.xml
@@ -136,6 +136,7 @@
      <file role="test" name="integration-tests-check.php"/>
      <file role="test" name="oauth-integration-tests-check.php"/>
     </dir>
+    <file role="test" name="kafka_consumer_get_rebalance_protocol.phpt"/>
     <file role="test" name="kafka_error_exception.phpt"/>
     <file role="test" name="message_headers.phpt"/>
     <file role="test" name="metadata_001.phpt"/>

--- a/tests/kafka_consumer_get_rebalance_protocol.phpt
+++ b/tests/kafka_consumer_get_rebalance_protocol.phpt
@@ -1,0 +1,17 @@
+--TEST--
+KafkaConsumer::getRebalanceProtocol() returns "NONE" before group join
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', 'localhost:9092');
+$conf->set('group.id', 'test-rebalance-protocol');
+$conf->setLogCb(function () {});
+
+$consumer = new RdKafka\KafkaConsumer($conf);
+
+$protocol = $consumer->getRebalanceProtocol();
+
+var_dump($protocol);
+--EXPECT--
+string(4) "NONE"

--- a/tests/kafka_consumer_get_rebalance_protocol.phpt
+++ b/tests/kafka_consumer_get_rebalance_protocol.phpt
@@ -4,7 +4,6 @@ KafkaConsumer::getRebalanceProtocol() returns "NONE" before group join
 <?php
 
 $conf = new RdKafka\Conf();
-$conf->set('metadata.broker.list', 'localhost:9092');
 $conf->set('group.id', 'test-rebalance-protocol');
 $conf->setLogCb(function () {});
 


### PR DESCRIPTION
Wraps `rd_kafka_rebalance_protocol()` — returns `"NONE"`, `"EAGER"`, or `"COOPERATIVE"`.

Needed for protocol-agnostic rebalance callbacks that branch between `assign()` and `incrementalAssign()`. No version guard required; available since librdkafka 1.4.0.

Closes #608