### PR TITLE
Fix integer overflow on batch_size in ConsumerTopic::consumeBatch()

### DIFF
--- a/tests/consume_batch_invalid_batch_size.phpt
+++ b/tests/consume_batch_invalid_batch_size.phpt
@@ -1,0 +1,23 @@
+--TEST--
+RdKafka\ConsumerTopic::consumeBatch() rejects an out-of-range $batch_size
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', '127.0.0.1:9092');
+
+$consumer = new RdKafka\Consumer($conf);
+$topic = $consumer->newTopic('test');
+
+foreach ([0, -1, PHP_INT_MAX] as $batchSize) {
+    try {
+        $topic->consumeBatch(0, 0, $batchSize);
+        echo "no exception for {$batchSize}\n";
+    } catch (\InvalidArgumentException $e) {
+        echo $e->getMessage(), "\n";
+    }
+}
+--EXPECTF--
+Out of range value '0' for batch_size
+Out of range value '-1' for batch_size
+Out of range value '%d' for batch_size

--- a/topic.c
+++ b/topic.c
@@ -354,7 +354,7 @@ PHP_METHOD(RdKafka_ConsumerTopic, consumeBatch)
         return;
     }
 
-    if (0 >= batch_size) {
+    if (batch_size <= 0 || (size_t) batch_size > SIZE_MAX / sizeof(*rkmessages)) {
         zend_throw_exception_ex(spl_ce_InvalidArgumentException, 0, "Out of range value '" ZEND_LONG_FMT "' for batch_size", batch_size);
         return;
     }
@@ -369,12 +369,12 @@ PHP_METHOD(RdKafka_ConsumerTopic, consumeBatch)
         return;
     }
 
-    rkmessages = malloc(sizeof(*rkmessages) * batch_size);
+    rkmessages = safe_emalloc(batch_size, sizeof(*rkmessages), 0);
 
     result = rd_kafka_consume_batch(intern->rkt, partition, timeout_ms, rkmessages, batch_size);
 
     if (result == -1) {
-        free(rkmessages);
+        efree(rkmessages);
         err = rd_kafka_last_error();
         zend_throw_exception(ce_kafka_exception, rd_kafka_err2str(err), err);
         return;
@@ -387,7 +387,7 @@ PHP_METHOD(RdKafka_ConsumerTopic, consumeBatch)
         }
     }
 
-    free(rkmessages);
+    efree(rkmessages);
 }
 /* }}} */
 


### PR DESCRIPTION
`consumeBatch()` validated only that batch_size is positive, then called malloc(sizeof(*rkmessages) * batch_size). That multiply overflows size_t for a large batch_size and the result is never NULL-checked, so an oversized batch_size crashes the worker on a NULL write or overruns an undersized buffer once rd_kafka_consume_batch fills it. consumeBatch now rejects sizes that would overflow the allocation (InvalidArgumentException, like the existing partition check) and uses safe_emalloc/efree. Reproduced under ASan.
