### PR TITLE
Free the rd_kafka_error_t returned by the transaction APIs

### DIFF
--- a/rdkafka.c
+++ b/rdkafka.c
@@ -843,7 +843,7 @@ PHP_METHOD(RdKafka_Producer, initTransactions)
 {
     kafka_object *intern;
     zend_long timeout_ms;
-    const rd_kafka_error_t *error;
+    rd_kafka_error_t *error;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &timeout_ms) == FAILURE) {
         return;
@@ -861,6 +861,7 @@ PHP_METHOD(RdKafka_Producer, initTransactions)
     }
 
     create_kafka_error(return_value, error);
+    rd_kafka_error_destroy(error);
     zend_throw_exception_object(return_value);
 }
 /* }}} */
@@ -870,7 +871,7 @@ PHP_METHOD(RdKafka_Producer, initTransactions)
 PHP_METHOD(RdKafka_Producer, beginTransaction)
 {
     kafka_object *intern;
-    const rd_kafka_error_t *error;
+    rd_kafka_error_t *error;
 
     intern = get_kafka_object(getThis());
     if (!intern) {
@@ -884,6 +885,7 @@ PHP_METHOD(RdKafka_Producer, beginTransaction)
     }
 
     create_kafka_error(return_value, error);
+    rd_kafka_error_destroy(error);
     zend_throw_exception_object(return_value);
 }
 /* }}} */
@@ -894,7 +896,7 @@ PHP_METHOD(RdKafka_Producer, commitTransaction)
 {
     kafka_object *intern;
     zend_long timeout_ms;
-    const rd_kafka_error_t *error;
+    rd_kafka_error_t *error;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &timeout_ms) == FAILURE) {
         return;
@@ -912,6 +914,7 @@ PHP_METHOD(RdKafka_Producer, commitTransaction)
     }
 
     create_kafka_error(return_value, error);
+    rd_kafka_error_destroy(error);
     zend_throw_exception_object(return_value);
 }
 /* }}} */
@@ -922,7 +925,7 @@ PHP_METHOD(RdKafka_Producer, abortTransaction)
 {
     kafka_object *intern;
     zend_long timeout_ms;
-    const rd_kafka_error_t *error;
+    rd_kafka_error_t *error;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &timeout_ms) == FAILURE) {
         return;
@@ -940,6 +943,7 @@ PHP_METHOD(RdKafka_Producer, abortTransaction)
     }
 
     create_kafka_error(return_value, error);
+    rd_kafka_error_destroy(error);
     zend_throw_exception_object(return_value);
 }
 /* }}} */
@@ -953,7 +957,7 @@ PHP_METHOD(RdKafka_Producer, sendOffsetsToTransaction)
     zend_long timeout_ms;
     rd_kafka_topic_partition_list_t *offsets;
     kafka_consumer_group_metadata_object *cgmd_intern;
-    const rd_kafka_error_t *error;
+    rd_kafka_error_t *error;
 
     if (zend_parse_parameters(ZEND_NUM_ARGS(), "hOl", &hoffsets, &zcgmd, ce_kafka_consumer_group_metadata, &timeout_ms) == FAILURE) {
         return;
@@ -980,6 +984,7 @@ PHP_METHOD(RdKafka_Producer, sendOffsetsToTransaction)
     }
 
     create_kafka_error(return_value, error);
+    rd_kafka_error_destroy(error);
     zend_throw_exception_object(return_value);
 }
 /* }}} */

--- a/tests/transaction_error_no_memleak.phpt
+++ b/tests/transaction_error_no_memleak.phpt
@@ -1,10 +1,17 @@
 --TEST--
 RdKafka\Producer::initTransactions() does not leak the rd_kafka_error_t on error
+--SKIPIF--
+<?php
+require __DIR__ . '/helpers/integration-tests-check.php';
+if (!class_exists("RdKafka\\KafkaErrorException")) {
+    echo "skip";
+}
 --FILE--
 <?php
+require __DIR__ . '/helpers/integration-tests-check.php';
 
 $conf = new RdKafka\Conf();
-$conf->set('metadata.broker.list', '127.0.0.1:9092');
+$conf->set('metadata.broker.list', getenv('TEST_KAFKA_BROKERS'));
 
 $producer = new RdKafka\Producer($conf);
 

--- a/tests/transaction_error_no_memleak.phpt
+++ b/tests/transaction_error_no_memleak.phpt
@@ -1,0 +1,24 @@
+--TEST--
+RdKafka\Producer::initTransactions() does not leak the rd_kafka_error_t on error
+--FILE--
+<?php
+
+$conf = new RdKafka\Conf();
+$conf->set('metadata.broker.list', '127.0.0.1:9092');
+
+$producer = new RdKafka\Producer($conf);
+
+// transactional.id is not configured, so each call returns an error object
+// that the extension owns and must destroy.
+for ($i = 0; $i < 5; $i++) {
+    try {
+        $producer->initTransactions(1000);
+    } catch (RdKafka\KafkaErrorException $e) {
+    }
+}
+
+unset($producer);
+
+echo "OK\n";
+--EXPECT--
+OK


### PR DESCRIPTION
`rd_kafka_init_transactions()`, begin/commit/abort, and send_offsets_to_transaction return an error object the caller owns and must free with rd_kafka_error_destroy(). The Producer wrappers passed it to create_kafka_error() to build the exception, then dropped it without destroying it, leaking one rd_kafka_error_t per failed transaction call. They now destroy the error after create_kafka_error() reads its fields. Confirmed with ASan: leaked allocations scale 1:1 with failed calls before the change, flat after.
