### PR TITLE
Document librdkafka <= 2.8.0 SASL/OAUTHBEARER segfault on process exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,21 @@ while ($producer->getOutQLen() > 0) {
 }
 ```
 
+## Known Issues
+
+### SASL/OAUTHBEARER: process segfault on exit with librdkafka < 2.10.0
+
+When using `sasl.mechanism=OAUTHBEARER` (including `enable.sasl.oauthbearer.unsecure.jwt=true`),
+processes that create and destroy multiple `KafkaConsumer` instances may segfault during PHP
+shutdown (exit code 139) even though all tests or application logic completed successfully.
+
+This is a librdkafka bug ([#4557](https://github.com/confluentinc/librdkafka/pull/4557)) where
+broker background threads are not fully joined before `rd_kafka_destroy()` returns. The orphaned
+threads access freed memory when the process exits.
+
+**Fix:** upgrade librdkafka to **>= 2.10.0**. The bug is present in all librdkafka versions up to
+and including 2.8.0 and was fixed in 2.10.0.
+
 ## Documentation
 
 https://arnaud-lb.github.io/php-rdkafka-doc/phpdoc/book.rdkafka.html  


### PR DESCRIPTION
## Summary

- Adds a **Known Issues** section to the README documenting a librdkafka bug that causes a segfault (exit 139) during PHP shutdown when using `SASL/OAUTHBEARER` with multiple sequential `KafkaConsumer` instances.

## Background

The crash manifests after all tests/logic complete successfully — PHP shuts down cleanly but the process then segfaults. It is **not** a bug in ext-rdkafka.

**Root cause:** librdkafka bug [confluentinc/librdkafka#4557](https://github.com/confluentinc/librdkafka/pull/4557) — broker background threads are not fully joined before `rd_kafka_destroy()` returns. Orphaned threads access freed memory at process exit.

- Present in all librdkafka versions up to and including **2.8.0**
- Fixed in **2.10.0** (no 2.9.0 release existed)
- Confirmed clean on librdkafka 2.14.1

## Test Plan

- [ ] Verify README renders correctly
- [ ] Confirm the linked librdkafka PR (#4557) is accurate